### PR TITLE
Feature support the Image struct method on `WebImage` and `AnimatedImage`

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - SDWebImage (5.1.0):
     - SDWebImage/Core (= 5.1.0)
   - SDWebImage/Core (5.1.0)
-  - SDWebImageSwiftUI (0.1.0):
+  - SDWebImageSwiftUI (0.1.1):
     - SDWebImage (~> 5.1)
 
 DEPENDENCIES:
@@ -18,7 +18,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   SDWebImage: fb387001955223213dde14bc08c8b73f371f8d8f
-  SDWebImageSwiftUI: 22254f3ced4f056602cd8167b64106ab6419c6e6
+  SDWebImageSwiftUI: fa0b13b16a92985532cd13931b88aea4ff7efb0b
 
 PODFILE CHECKSUM: 146734166216dd8fc1597433cc675999454ed4b2
 

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -15,9 +15,11 @@ struct ContentView: View {
     var body: some View {
         VStack {
             WebImage(url: URL(string: "https://nokiatech.github.io/heif/content/images/ski_jump_1440x960.heic"))
+                .resizable()
                 .scaledToFit()
                 .frame(width: CGFloat(300), height: CGFloat(300), alignment: .center)
             AnimatedImage(url: URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"), options: [.progressiveLoad])
+                .resizable()
                 .scaledToFill()
                 .frame(width: CGFloat(400), height: CGFloat(300), alignment: .center)
         }

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SDWebImage/SDWebImage.git",
         "state": {
           "branch": null,
-          "revision": "0a3cd255a655b73fb3b3437acf2ab506b5c0c9c6",
-          "version": "5.1.0"
+          "revision": "9c1682e37bf3486daccd313fcbcd7fd90a2064f4",
+          "version": "5.2.0"
         }
       }
     ]

--- a/SDWebImageSwiftUI.xcodeproj/project.pbxproj
+++ b/SDWebImageSwiftUI.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		326E480A23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E480923431C0F00C633E9 /* ImageViewWrapper.swift */; };
+		326E480B23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E480923431C0F00C633E9 /* ImageViewWrapper.swift */; };
+		326E480C23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E480923431C0F00C633E9 /* ImageViewWrapper.swift */; };
+		326E480D23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E480923431C0F00C633E9 /* ImageViewWrapper.swift */; };
 		32C43DE622FD54CD00BE87F5 /* SDWebImageSwiftUI.h in Headers */ = {isa = PBXBuildFile; fileRef = 32C43DE422FD54CD00BE87F5 /* SDWebImageSwiftUI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		32C43DEA22FD577300BE87F5 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32C43DE922FD577300BE87F5 /* SDWebImage.framework */; };
 		32C43DEB22FD577300BE87F5 /* SDWebImage.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 32C43DE922FD577300BE87F5 /* SDWebImage.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -85,6 +89,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		326E480923431C0F00C633E9 /* ImageViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewWrapper.swift; sourceTree = "<group>"; };
 		32C43DCC22FD540D00BE87F5 /* SDWebImageSwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SDWebImageSwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		32C43DDC22FD54C600BE87F5 /* ImageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageManager.swift; sourceTree = "<group>"; };
 		32C43DDE22FD54C600BE87F5 /* WebImage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebImage.swift; sourceTree = "<group>"; };
@@ -174,6 +179,7 @@
 				32C43DDE22FD54C600BE87F5 /* WebImage.swift */,
 				32C43DDF22FD54C600BE87F5 /* AnimatedImage.swift */,
 				32C43E3122FD5DE100BE87F5 /* SDWebImageSwiftUI.swift */,
+				326E480923431C0F00C633E9 /* ImageViewWrapper.swift */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -385,6 +391,7 @@
 			files = (
 				32C43E1722FD583700BE87F5 /* WebImage.swift in Sources */,
 				32C43E3222FD5DE100BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
+				326E480A23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
 				32C43E1622FD583700BE87F5 /* ImageManager.swift in Sources */,
 				32C43E1822FD583700BE87F5 /* AnimatedImage.swift in Sources */,
 			);
@@ -396,6 +403,7 @@
 			files = (
 				32C43E1A22FD583700BE87F5 /* WebImage.swift in Sources */,
 				32C43E3322FD5DF400BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
+				326E480B23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
 				32C43E1922FD583700BE87F5 /* ImageManager.swift in Sources */,
 				32C43E1B22FD583700BE87F5 /* AnimatedImage.swift in Sources */,
 			);
@@ -407,6 +415,7 @@
 			files = (
 				32C43E1D22FD583800BE87F5 /* WebImage.swift in Sources */,
 				32C43E3422FD5DF400BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
+				326E480C23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
 				32C43E1C22FD583800BE87F5 /* ImageManager.swift in Sources */,
 				32C43E1E22FD583800BE87F5 /* AnimatedImage.swift in Sources */,
 			);
@@ -418,6 +427,7 @@
 			files = (
 				32C43E2022FD583800BE87F5 /* WebImage.swift in Sources */,
 				32C43E3522FD5DF400BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
+				326E480D23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
 				32C43E1F22FD583800BE87F5 /* ImageManager.swift in Sources */,
 				32C43E2122FD583800BE87F5 /* AnimatedImage.swift in Sources */,
 			);

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -73,9 +73,10 @@ public struct AnimatedImage : ViewRepresentable {
     
     func layoutView(_ view: AnimatedImageViewWrapper, context: ViewRepresentableContext<AnimatedImage>) {
         // AspectRatio
-        if let aspectRatio = imageLayout.aspectRatio {
-            // Not implements
+        if let _ = imageLayout.aspectRatio {
+            // TODO: Needs layer transform and geometry calculation
         }
+        
         // ContentMode
         switch imageLayout.contentMode {
         case .fit:
@@ -91,6 +92,7 @@ public struct AnimatedImage : ViewRepresentable {
             view.wrapped.contentMode = .scaleToFill
             #endif
         }
+        
         // RenderingMode
         if let renderingMode = imageLayout.renderingMode {
             switch renderingMode {
@@ -111,6 +113,7 @@ public struct AnimatedImage : ViewRepresentable {
                 break
             }
         }
+        
         // Interpolation
         if let interpolation = imageLayout.interpolation {
             switch interpolation {
@@ -129,15 +132,16 @@ public struct AnimatedImage : ViewRepresentable {
         } else {
             view.interpolationQuality = .default
         }
+        
         // Antialiased
         view.shouldAntialias = imageLayout.antialiased
         
         // Display
         #if os(macOS)
-        view.updateConstraintsIfNeeded()
+        view.needsLayout = true
         view.needsDisplay = true
         #else
-        view.updateConstraintsIfNeeded()
+        view.setNeedsLayout()
         view.setNeedsDisplay()
         #endif
     }

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -14,10 +14,10 @@ class ImageManager : ObservableObject {
     
     var objectWillChange = PassthroughSubject<ImageManager, Never>()
     
-    private var manager = SDWebImageManager.shared
-    private weak var currentOperation: SDWebImageOperation? = nil
+    var manager = SDWebImageManager.shared
+    weak var currentOperation: SDWebImageOperation? = nil
     
-    var image: Image? {
+    var image: PlatformImage? {
         willSet {
             objectWillChange.send(self)
         }
@@ -36,11 +36,7 @@ class ImageManager : ObservableObject {
     func load() {
         currentOperation = manager.loadImage(with: url, options: options, context: context, progress: nil) { (image, data, error, cacheType, _, _) in
             if let image = image {
-                #if os(macOS)
-                self.image = Image(nsImage: image)
-                #else
-                self.image = Image(uiImage: image)
-                #endif
+                self.image = image
             }
         }
     }

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -1,0 +1,61 @@
+/*
+* This file is part of the SDWebImage package.
+* (c) DreamPiggy <lizhuoli1126@126.com>
+*
+* For the full copyright and license information, please view the LICENSE
+* file that was distributed with this source code.
+*/
+
+import Foundation
+import SDWebImage
+
+// View Wrapper
+public class AnimatedImageViewWrapper : PlatformView {
+    var wrapped = SDAnimatedImageView()
+    var interpolationQuality = CGInterpolationQuality.default
+    var shouldAntialias = false
+    
+    override public func draw(_ rect: CGRect) {
+        #if os(macOS)
+        guard let ctx = NSGraphicsContext.current?.cgContext else {
+            return
+        }
+        #else
+        guard let ctx = UIGraphicsGetCurrentContext() else {
+            return
+        }
+        #endif
+        ctx.interpolationQuality = interpolationQuality
+        ctx.setShouldAntialias(shouldAntialias)
+    }
+    
+    public override init(frame frameRect: CGRect) {
+        super.init(frame: frameRect)
+        addSubview(wrapped)
+        wrapped.bindFrameToSuperviewBounds()
+    }
+    
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        addSubview(wrapped)
+        wrapped.bindFrameToSuperviewBounds()
+    }
+}
+
+extension PlatformView {
+    /// Adds constraints to this `UIView` instances `superview` object to make sure this always has the same size as the superview.
+    /// Please note that this has no effect if its `superview` is `nil` – add this `UIView` instance as a subview before calling this.
+    func bindFrameToSuperviewBounds() {
+        guard let superview = self.superview else {
+            print("Error! `superview` was nil – call `addSubview(view: UIView)` before calling `bindFrameToSuperviewBounds()` to fix this.")
+            return
+        }
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.topAnchor.constraint(equalTo: superview.topAnchor, constant: 0).isActive = true
+        self.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: 0).isActive = true
+        self.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 0).isActive = true
+        self.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: 0).isActive = true
+
+    }
+}

--- a/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
+++ b/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
@@ -15,6 +15,12 @@ typealias PlatformImage = NSImage
 typealias PlatformImage = UIImage
 #endif
 
+#if os(macOS)
+public typealias PlatformView = NSView
+#else
+public typealias PlatformView = UIView
+#endif
+
 extension Image {
     init(platformImage: PlatformImage) {
         #if os(macOS)

--- a/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
+++ b/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
@@ -9,6 +9,22 @@
 import Foundation
 import SwiftUI
 
+#if os(macOS)
+typealias PlatformImage = NSImage
+#else
+typealias PlatformImage = UIImage
+#endif
+
+extension Image {
+    init(platformImage: PlatformImage) {
+        #if os(macOS)
+        self.init(nsImage: platformImage)
+        #else
+        self.init(uiImage: platformImage)
+        #endif
+    }
+}
+
 #if !os(watchOS)
 
 #if os(macOS)

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -81,3 +81,17 @@ extension WebImage {
         configure { $0.antialiased(isAntialiased) }
     }
 }
+
+
+#if DEBUG
+struct WebImage_Previews : PreviewProvider {
+    static var previews: some View {
+        Group {
+            WebImage(url: URL(string: "https://raw.githubusercontent.com/SDWebImage/SDWebImage/master/SDWebImage_logo.png"))
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .padding()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
We use a wrapper instead of original `SDAnimatedImageView` for avoid issues.

Try to solve #3 
Fix #6 


For now, some of the modifier is not supported on the `AnimatedImage`, because of the limitation of SwiftUI to briding UIKit/AppKit. Maybe can be solved in the future.