### PR TITLE
Fix the support on watchOS. Using the Platform Image class instead of hard-coded `SDAnimatedImage` class

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -13,7 +13,7 @@ import SDWebImage
 
 // Data Binding Object
 final class AnimatedImageModel : ObservableObject {
-    @Published var image: SDAnimatedImage?
+    @Published var image: PlatformImage?
     @Published var url: URL?
 }
 
@@ -146,7 +146,7 @@ public struct AnimatedImage : ViewRepresentable {
         #endif
     }
     
-    public func image(_ image: SDAnimatedImage?) -> Self {
+    public func image(_ image: PlatformImage?) -> Self {
         imageModel.image = image
         return self
     }
@@ -202,7 +202,7 @@ public struct AnimatedImage : ViewRepresentable {
 }
 
 extension AnimatedImage {
-    public init(url: URL?, placeholder: SDAnimatedImage? = nil, options: SDWebImageOptions = [], context: [SDWebImageContextOption : Any]? = nil) {
+    public init(url: URL?, placeholder: PlatformImage? = nil, options: SDWebImageOptions = [], context: [SDWebImageContextOption : Any]? = nil) {
         self.webOptions = options
         self.webContext = context
         self.imageModel.url = url

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -9,6 +9,8 @@
 import Foundation
 import SDWebImage
 
+#if !os(watchOS)
+
 // View Wrapper
 public class AnimatedImageViewWrapper : PlatformView {
     var wrapped = SDAnimatedImageView()
@@ -59,3 +61,5 @@ extension PlatformView {
 
     }
 }
+
+#endif

--- a/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
+++ b/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
@@ -10,15 +10,9 @@ import Foundation
 import SwiftUI
 
 #if os(macOS)
-typealias PlatformImage = NSImage
+public typealias PlatformImage = NSImage
 #else
-typealias PlatformImage = UIImage
-#endif
-
-#if os(macOS)
-public typealias PlatformView = NSView
-#else
-public typealias PlatformView = UIView
+public typealias PlatformImage = UIImage
 #endif
 
 extension Image {
@@ -31,14 +25,25 @@ extension Image {
     }
 }
 
-#if !os(watchOS)
+#if os(macOS)
+public typealias PlatformView = NSView
+#endif
+#if os(iOS) || os(tvOS)
+public typealias PlatformView = UIView
+#endif
+#if os(watchOS)
+public typealias PlatformView = WKInterfaceObject
+#endif
 
 #if os(macOS)
 typealias ViewRepresentable = NSViewRepresentable
 typealias ViewRepresentableContext = NSViewRepresentableContext
-#else
+#endif
+#if os(iOS) || os(tvOS)
 typealias ViewRepresentable = UIViewRepresentable
 typealias ViewRepresentableContext = UIViewRepresentableContext
 #endif
-
+#if os(watchOS)
+typealias ViewRepresentable = WKInterfaceObjectRepresentable
+typealias ViewRepresentableContext = WKInterfaceObjectRepresentableContext
 #endif


### PR DESCRIPTION
Solve the compile issue on watchOS.
AnimatedImage now supports the UIImage/NSImage, just the same as SDWebImage itself.