### PR TITLE
Supports AnimatedImage animation control using of SwiftUI Binding

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/DetailView.swift
+++ b/Example/SDWebImageSwiftUIDemo/DetailView.swift
@@ -13,6 +13,7 @@ struct DetailView: View {
     let url: String
     let animated: Bool
     @State var progress: CGFloat = 1
+    @State var isAnimating: Bool = true
     
     var body: some View {
         VStack {
@@ -24,7 +25,7 @@ struct DetailView: View {
             Spacer()
             HStack {
                 if animated {
-                    AnimatedImage(url: URL(string:url), options: [.progressiveLoad])
+                    AnimatedImage(url: URL(string:url), options: [.progressiveLoad], isAnimating: $isAnimating)
                     .onProgress(perform: { (receivedSize, expectedSize) in
                         // SwiftUI engine itself ensure the main queue dispatch
                         if (expectedSize >= 0) {
@@ -35,6 +36,9 @@ struct DetailView: View {
                     })
                     .resizable()
                     .scaledToFit()
+                    .navigationBarItems(trailing: Button(isAnimating ? "Stop" : "Start") {
+                        self.isAnimating.toggle()
+                    })
                 } else {
                     WebImage(url: URL(string:url), options: [.progressiveLoad])
                     .onProgress(perform: { (receivedSize, expectedSize) in

--- a/README.md
+++ b/README.md
@@ -85,20 +85,24 @@ var body: some View {
 ```swift
 var body: some View {
     Group {
-        AnimatedImage(url: URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif")) // Network
+        // Network
+        AnimatedImage(url: URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"))
         .onFailure(perform: { (error) in
             // Error
         })
         .scaledToFit()
-        AnimatedImage(data: try! Data(contentsOf: URL(fileURLWithPath: "/tmp/foo.webp"))) // Data
+        // Data
+        AnimatedImage(data: try! Data(contentsOf: URL(fileURLWithPath: "/tmp/foo.webp")))
         .customLoopCount(1)
-        AnimatedImage(name: "animation1") // Bundle (not Asset Catalog)
+        // Bundle (not Asset Catalog)
+        AnimatedImage(name: "animation1", isAnimating: $isAnimating)) // Animation control binding
         .maxBufferSize(.max)
     }
 }
 ```
 
 - [x] Supports network image as well as local data and bundle image
+- [x] Supports animation control using the SwiftUI Binding
 - [x] Supports advanced control like loop count, incremental load, buffer size.
 
 Note: `AnimatedImage` supports both image url or image data for animated image format. Which use the SDWebImage's [Animated ImageView](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#animated-image-50) for internal implementation.

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -129,6 +129,12 @@ public struct AnimatedImage : PlatformViewRepresentable {
                 }
             }
         }
+        
+        #if os(macOS)
+        if self.isAnimating != view.wrapped.animates {
+            view.wrapped.animates = self.isAnimating
+        }
+        #else
         if self.isAnimating != view.wrapped.isAnimating {
             if self.isAnimating {
                 view.wrapped.startAnimating()
@@ -136,6 +142,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
                 view.wrapped.stopAnimating()
             }
         }
+        #endif
         
         configureView(view, context: context)
         layoutView(view, context: context)


### PR DESCRIPTION
Add support for Animation Control of `AnimatedImage` !

This feature is really useful for animation, like something logic to stop animation when doing transition or hover. It's quite common in iOS App.

This API design use the [Binding](https://developer.apple.com/documentation/swiftui/binding) of SwiftUI. I reference the built-in View like `Toggle` and `Sheet`. Which make it easy for user to use (Just one line of code)

```
@State var isAnimating: Bool = true // I just need to touch this status

body {
    AnimatedImage(url: URL(string:url), options: [.progressiveLoad], isAnimating: $isAnimating)
}
````