### PR TITLE
Using the frame layout for view wrapper instead of Autolayout. Solve the issue when running on AppKit (not Catalyst)

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -31,34 +31,26 @@ public class AnimatedImageViewWrapper : PlatformView {
         ctx.setShouldAntialias(shouldAntialias)
     }
     
+    #if os(macOS)
+    public override func layout() {
+        super.layout()
+        wrapped.frame = self.bounds
+    }
+    #else
+    public override func layoutSubviews() {
+        super.layoutSubviews()
+        wrapped.frame = self.bounds
+    }
+    #endif
+    
     public override init(frame frameRect: CGRect) {
         super.init(frame: frameRect)
         addSubview(wrapped)
-        wrapped.bindFrameToSuperviewBounds()
     }
     
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
         addSubview(wrapped)
-        wrapped.bindFrameToSuperviewBounds()
-    }
-}
-
-extension PlatformView {
-    /// Adds constraints to this `UIView` instances `superview` object to make sure this always has the same size as the superview.
-    /// Please note that this has no effect if its `superview` is `nil` – add this `UIView` instance as a subview before calling this.
-    func bindFrameToSuperviewBounds() {
-        guard let superview = self.superview else {
-            print("Error! `superview` was nil – call `addSubview(view: UIView)` before calling `bindFrameToSuperviewBounds()` to fix this.")
-            return
-        }
-
-        self.translatesAutoresizingMaskIntoConstraints = false
-        self.topAnchor.constraint(equalTo: superview.topAnchor, constant: 0).isActive = true
-        self.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: 0).isActive = true
-        self.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 0).isActive = true
-        self.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: 0).isActive = true
-
     }
 }
 


### PR DESCRIPTION
The Autolayout engine seems does not works as expected, because when running on AppKit. The SwiftUI layout system.

Seems looks like the issue in #3 , some internal hack of SwiftUI engine break this. However, use the frame layout solve the problem.