### PR TITLE
Fix WebImage showing empty image when entering edit mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ profile
 DerivedData
 *.hmap
 *.ipa
+IDEWorkspaceChecks.plist
 
 # Bundler
 .bundle

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,10 +8,10 @@ PODS:
   - libwebp/mux (1.0.3):
     - libwebp/demux
   - libwebp/webp (1.0.3)
-  - SDWebImage (5.2.2):
-    - SDWebImage/Core (= 5.2.2)
-  - SDWebImage/Core (5.2.2)
-  - SDWebImageSwiftUI (0.3.0):
+  - SDWebImage (5.2.3):
+    - SDWebImage/Core (= 5.2.3)
+  - SDWebImage/Core (5.2.3)
+  - SDWebImageSwiftUI (0.3.1):
     - SDWebImage (~> 5.1)
   - SDWebImageWebPCoder (0.2.5):
     - libwebp (~> 1.0)
@@ -22,7 +22,7 @@ DEPENDENCIES:
   - SDWebImageWebPCoder
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - libwebp
     - SDWebImage
     - SDWebImageWebPCoder
@@ -33,10 +33,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
-  SDWebImage: 5fcdb02cc35e05fc35791ec514b191d27189f872
-  SDWebImageSwiftUI: 9fa220c3c9a69a383f2db5fabc97748ac4e4b696
+  SDWebImage: 46a7f73228f84ce80990c786e4372cf4db5875ce
+  SDWebImageSwiftUI: 1b67183dd2ef0321b2ccf578775de8e47eaceb77
   SDWebImageWebPCoder: 947093edd1349d820c40afbd9f42acb6cdecd987
 
 PODFILE CHECKSUM: 3fb06a5173225e197f3a4bf2be7e5586a693257a
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.8.3

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -17,7 +17,8 @@ extension String : Identifiable {
     }
 }
 
-let imageURLs = [
+struct ContentView: View {
+    @State var imageURLs = [
     "http://assets.sbnation.com/assets/2512203/dogflops.gif",
     "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif",
     "http://apng.onevcat.com/assets/elephant.png",
@@ -30,8 +31,6 @@ let imageURLs = [
     "https://nokiatech.github.io/heif/content/image_sequences/starfield_animation.heic",
     "https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png",
     "http://via.placeholder.com/200x200.jpg"]
-
-struct ContentView: View {
     @State var animated: Bool = true // You can change between WebImage/AnimatedImage
     
     var body: some View {
@@ -73,30 +72,37 @@ struct ContentView: View {
     }
     
     func contentView() -> some View {
-        List(imageURLs) { url in
-            NavigationLink(destination: DetailView(url: url, animated: self.animated)) {
-                HStack {
-                    #if os(iOS) || os(tvOS) || os(macOS)
-                    if self.animated {
-                        AnimatedImage(url: URL(string:url))
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
-                    } else {
+        List {
+            ForEach(imageURLs) { url in
+                NavigationLink(destination: DetailView(url: url, animated: self.animated)) {
+                    HStack {
+                        #if os(iOS) || os(tvOS) || os(macOS)
+                        if self.animated {
+                            AnimatedImage(url: URL(string:url))
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
+                        } else {
+                            WebImage(url: URL(string:url))
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
+                        }
+                        #else
                         WebImage(url: URL(string:url))
                         .resizable()
                         .scaledToFit()
                         .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
+                        #endif
+                        Text((url as NSString).lastPathComponent)
                     }
-                    #else
-                    WebImage(url: URL(string:url))
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
-                    #endif
-                    Text((url as NSString).lastPathComponent)
                 }
             }
+            .onDelete(perform: { (indexSet) in
+                indexSet.forEach { (index) in
+                    self.imageURLs.remove(at: index)
+                }
+            })
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Tips:
 
 1. Use `Switch` (right-click on macOS) to switch between `WebImage` and `AnimatedImage`.
 2. Use `Reload` (right-click on macOS/force press on watchOS) to clear cache.
+3. Use `Swipe` to delete one image item.
 
 ## Screenshot
 

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -45,6 +45,9 @@ public struct WebImage : View {
             let emptyImage = Image(uiImage: UIImage())
             #endif
             image = emptyImage
+            // load remote image here, SwiftUI sometimes will create a new View struct without calling `onAppear` (like enter EditMode) :)
+            // this can ensure we load the image, SDWebImage take care of the duplicated query
+            self.imageManager.load()
         }
         return configurations.reduce(image) { (previous, configuration) in
             configuration(previous)


### PR DESCRIPTION
This fix #19 

Maybe the main reason is that SwiftUI internal trick, when entering edit mode, it will recreate your `View.doby` treenode, but the new created `View` struct does not trigger a `onAppear` method call. I don't think it's a designed behavior, I'll send a bugreport to Apple later.

But currentlly, we can do a better way to handle possible future cases like this. We query the image url once we can not load the image, SDWebImage Core will handle the duplicated loading call, it's OK on performance.