### PR TITLE
Try to stop animating when dismantle UIViewRepresentable, fix the potential leak (bug ?) for AnmatedImage

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
   - SDWebImage (5.2.3):
     - SDWebImage/Core (= 5.2.3)
   - SDWebImage/Core (5.2.3)
-  - SDWebImageSwiftUI (0.3.1):
+  - SDWebImageSwiftUI (0.3.2):
     - SDWebImage (~> 5.1)
   - SDWebImageWebPCoder (0.2.5):
     - libwebp (~> 1.0)
@@ -34,9 +34,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
   SDWebImage: 46a7f73228f84ce80990c786e4372cf4db5875ce
-  SDWebImageSwiftUI: 1b67183dd2ef0321b2ccf578775de8e47eaceb77
+  SDWebImageSwiftUI: a8a03ef596dde2e9668a76794f6c59d194289bb0
   SDWebImageWebPCoder: 947093edd1349d820c40afbd9f42acb6cdecd987
 
 PODFILE CHECKSUM: 3fb06a5173225e197f3a4bf2be7e5586a693257a
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.8.4

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -129,6 +129,10 @@ public struct AnimatedImage : PlatformViewRepresentable {
     public func updateNSView(_ nsView: AnimatedImageViewWrapper, context: NSViewRepresentableContext<AnimatedImage>) {
         updateView(nsView, context: context)
     }
+    
+    public static func dismantleNSView(_ nsView: AnimatedImageViewWrapper, coordinator: ()) {
+        dismantleView(nsView, coordinator: coordinator)
+    }
     #else
     public func makeUIView(context: UIViewRepresentableContext<AnimatedImage>) -> AnimatedImageViewWrapper {
         makeView(context: context)
@@ -136,6 +140,10 @@ public struct AnimatedImage : PlatformViewRepresentable {
     
     public func updateUIView(_ uiView: AnimatedImageViewWrapper, context: UIViewRepresentableContext<AnimatedImage>) {
         updateView(uiView, context: context)
+    }
+    
+    public static func dismantleUIView(_ uiView: AnimatedImageViewWrapper, coordinator: ()) {
+        dismantleView(uiView, coordinator: coordinator)
     }
     #endif
     
@@ -173,6 +181,14 @@ public struct AnimatedImage : PlatformViewRepresentable {
         
         configureView(view, context: context)
         layoutView(view, context: context)
+    }
+    
+    static func dismantleView(_ view: AnimatedImageViewWrapper, coordinator: ()) {
+        #if os(macOS)
+        view.wrapped.animates = false
+        #else
+        view.wrapped.stopAnimating()
+        #endif
     }
     
     func layoutView(_ view: AnimatedImageViewWrapper, context: PlatformViewRepresentableContext<AnimatedImage>) {


### PR DESCRIPTION
If we don't override `dismantleView` method, seems SwiftUI will keep a strong retain to that `SDAnmatedImageView` and cause leak ? Like a bug but we can workaround.