### PR TITLE
Performance enhancement to WebImage/AnimatedImage, to avoid extra query for SDWebImage

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -360,15 +360,6 @@ public struct AnimatedImage : PlatformViewRepresentable {
         
         // Antialiased
         view.shouldAntialias = imageLayout.antialiased
-        
-        // Display
-        #if os(macOS)
-        view.needsLayout = true
-        view.needsDisplay = true
-        #else
-        view.setNeedsLayout()
-        view.setNeedsDisplay()
-        #endif
         #endif
     }
     

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -29,17 +29,24 @@ class ImageManager : ObservableObject {
     }
     
     func load() {
+        if currentOperation != nil {
+            return
+        }
         currentOperation = manager.loadImage(with: url, options: options, context: context, progress: { [weak self] (receivedSize, expectedSize, _) in
             self?.progressBlock?(receivedSize, expectedSize)
-        }) { [weak self] (image, data, error, cacheType, _, _) in
+        }) { [weak self] (image, data, error, cacheType, finished, _) in
             guard let self = self else {
                 return
             }
             if let image = image {
                 self.image = image
-                self.successBlock?(image, cacheType)
-            } else {
-                self.failureBlock?(error ?? NSError())
+            }
+            if finished {
+                if let image = image {
+                    self.successBlock?(image, cacheType)
+                } else {
+                    self.failureBlock?(error ?? NSError())
+                }
             }
         }
     }


### PR DESCRIPTION
+ Check the current operation and avoid extra query, this can increase performance, even SDWebImage does not query multiple times
+ Don't need to setNeedsDisplay on SwiftUI representable, because SwfitUI will do this automatically