### PR TITLE
Fix that AnimatedImage on macOS can not restart animation after first stop

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -211,6 +211,11 @@ public struct AnimatedImage : PlatformViewRepresentable {
     }
     
     func updateView(_ view: AnimatedImageViewWrapper, context: PlatformViewRepresentableContext<AnimatedImage>) {
+        // macOS SDAnimatedImageView.animates should initialize to true in advance before set image
+        #if os(macOS)
+        view.wrapped.animates = true
+        #endif
+        
         if let image = imageModel.image {
             #if os(watchOS)
             view.wrapped.setImage(image)
@@ -228,9 +233,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
         
         #if os(macOS)
-        if self.isAnimating != view.wrapped.animates {
-            view.wrapped.animates = self.isAnimating
-        }
+        view.wrapped.animates = self.isAnimating
         #else
         if self.isAnimating != view.wrapped.isAnimating {
             if self.isAnimating {


### PR DESCRIPTION
Because there are always a new set image method call.

This need upstram SDWebImage to change its behavior to match the intuition from user side. This can be done by SDWebImage 5.3.0.

Related issue: https://github.com/SDWebImage/SDWebImage/pull/2874

Currently, SDWebImageSwiftUI dependent `SDWebImage ~> 5.1.0`, so this compatible code is still kept. In the future we will bump the version of SDWebImage dependency.