### PR TITLE
Refactory the indicator API on WebImage, using the same design pattern like SwiftUI, return some View

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,10 +8,10 @@ PODS:
   - libwebp/mux (1.0.3):
     - libwebp/demux
   - libwebp/webp (1.0.3)
-  - SDWebImage (5.2.3):
-    - SDWebImage/Core (= 5.2.3)
-  - SDWebImage/Core (5.2.3)
-  - SDWebImageSwiftUI (0.4.2):
+  - SDWebImage (5.2.5):
+    - SDWebImage/Core (= 5.2.5)
+  - SDWebImage/Core (5.2.5)
+  - SDWebImageSwiftUI (0.5.2):
     - SDWebImage (~> 5.1)
   - SDWebImageWebPCoder (0.2.5):
     - libwebp (~> 1.0)
@@ -33,8 +33,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
-  SDWebImage: 46a7f73228f84ce80990c786e4372cf4db5875ce
-  SDWebImageSwiftUI: b91be76ecb0cdf74c18f6cd92aae8f19a9ded02d
+  SDWebImage: 4eabf2fa6695c95c47724214417a9c036c965e4a
+  SDWebImageSwiftUI: 3a3e3aa707aeedf024af6f9c718177f681edf9de
   SDWebImageWebPCoder: 947093edd1349d820c40afbd9f42acb6cdecd987
 
 PODFILE CHECKSUM: 3fb06a5173225e197f3a4bf2be7e5586a693257a

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -96,8 +96,8 @@ struct ContentView: View {
                         } else {
                             #if os(macOS) || os(iOS) || os(tvOS)
                             WebImage(url: URL(string:url))
-                            .indicator(.activity)
                             .resizable()
+                            .indicator(.activity)
                             .scaledToFit()
                             .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
                             .animation(.easeInOut(duration: 0.5))

--- a/Example/SDWebImageSwiftUIDemo/DetailView.swift
+++ b/Example/SDWebImageSwiftUIDemo/DetailView.swift
@@ -57,17 +57,17 @@ struct DetailView: View {
             } else {
                 #if os(macOS) || os(iOS) || os(tvOS)
                 WebImage(url: URL(string:url), options: [.progressiveLoad])
-                .indicator(.progress)
                 .resizable()
+                .indicator(.progress)
                 .scaledToFit()
                 #else
                 WebImage(url: URL(string:url), options: [.progressiveLoad])
+                .resizable()
                 .indicator { isAnimating, progress in
                     ProgressBar(value: progress)
                     .foregroundColor(.blue)
                     .frame(maxHeight: 6)
                 }
-                .resizable()
                 .scaledToFit()
                 #endif
             }

--- a/Example/SDWebImageSwiftUIDemo/DetailView.swift
+++ b/Example/SDWebImageSwiftUIDemo/DetailView.swift
@@ -62,13 +62,11 @@ struct DetailView: View {
                 .scaledToFit()
                 #else
                 WebImage(url: URL(string:url), options: [.progressiveLoad])
-                .indicator(
-                    Indicator { isAnimating, progress in
-                        ProgressBar(value: progress)
-                        .foregroundColor(.blue)
-                        .frame(maxHeight: 6)
-                    }
-                )
+                .indicator { isAnimating, progress in
+                    ProgressBar(value: progress)
+                    .foregroundColor(.blue)
+                    .frame(maxHeight: 6)
+                }
                 .resizable()
                 .scaledToFit()
                 #endif

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ var body: some View {
         .onSuccess { image, cacheType in
             // Success
         }
-        .indicator(.activity) // Activity Indicator
         .resizable()
+        .indicator(.activity) // Activity Indicator
         .scaledToFit()
         .frame(width: 300, height: 300, alignment: .center)
 }

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -65,7 +65,7 @@ public class ProgressIndicatorWrapper : PlatformView {
     #if os(macOS)
     public override func layout() {
         super.layout()
-        wrapped.setFrameOrigin(CGPoint(x: (self.bounds.width - wrapped.frame.width) / 2, y: (self.bounds.height - wrapped.frame.height) / 2))
+        wrapped.setFrameOrigin(CGPoint(x: round(self.bounds.width - wrapped.frame.width) / 2, y: round(self.bounds.height - wrapped.frame.height) / 2))
     }
     #else
     public override func layoutSubviews() {

--- a/SDWebImageSwiftUI/Classes/Indicator/ProgressIndicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/ProgressIndicator.swift
@@ -67,6 +67,9 @@ public struct ProgressIndicator: PlatformViewRepresentable {
         view.style = .bar
         view.isDisplayedWhenStopped = false
         view.controlSize = .small
+        view.frame = CGRect(x: 0, y: 0, width: 160, height: 0) // Width from `UIProgressView` default width
+        view.sizeToFit()
+        view.autoresizingMask = [.maxXMargin, .minXMargin, .maxYMargin, .minYMargin]
         return nsView
     }
     

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -179,6 +179,14 @@ extension WebImage {
         result.indicator = indicator
         return result
     }
+    
+    /// Associate a indicator when loading image with url, convenient method with block
+    /// - Parameter indicator: The indicator type, see `Indicator`
+    public func indicator<T>(@ViewBuilder builder: @escaping (_ isAnimating: Binding<Bool>, _ progress: Binding<CGFloat>) -> T) -> WebImage where T : View {
+        var result = self
+        result.indicator = Indicator(builder: builder)
+        return result
+    }
 }
 
 #if DEBUG


### PR DESCRIPTION
This allows the following syntax:

```swift
WebImage(url: url)
.indicator { _, progress in
    ProgressBar(value: progress)
}
```

Instead of dummy syntax previously

```swift
WebImage(url: url)
.indicator ( 
    Indicator { _, progress in
        ProgressBar(value: progress)
    }
)
```