### PR TITLE
Change the implementation of indicator by using view modifier

### DIFF
--- a/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
@@ -23,16 +23,15 @@ public struct Indicator<T> where T : View {
     }
 }
 
-/// A implementation detail View with indicator
+/// A implementation detail View Modifier with indicator
 /// SwiftUI View Modifier construced by using a internal View type which modify the `body`
 /// It use type system to represent the view hierarchy, and Swift `some View` syntax to hide the type detail for users
-struct IndicatorView<T, Content> : View where T : View, Content : View {
+struct IndicatorViewModifier<T> : ViewModifier where T : View {
     @ObservedObject var imageManager: ImageManager
     
     var indicator: Indicator<T>
-    var content: Content
     
-    var body: some View {
+    func body(content: Content) -> some View {
         if (imageManager.image != nil) && !imageManager.isLoading {
             // Disable Indiactor
             return AnyView(content)
@@ -45,12 +44,6 @@ struct IndicatorView<T, Content> : View where T : View, Content : View {
                 }
             )
         }
-    }
-    
-    public init(_ view: Content, indicator: Indicator<T>, imageManager: ImageManager) {
-        self.content = view
-        self.indicator = indicator
-        self.imageManager = imageManager
     }
 }
 

--- a/SDWebImageSwiftUI/Classes/Indicator/ProgressIndicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/ProgressIndicator.swift
@@ -35,7 +35,7 @@ public struct ProgressIndicator: PlatformViewRepresentable {
         case .bar:
             progressStyle = .bar
         #endif
-        default:
+        case .default:
             progressStyle = .default
         }
         let uiView = ProgressIndicatorWrapper()
@@ -99,7 +99,9 @@ public struct ProgressIndicator: PlatformViewRepresentable {
 extension ProgressIndicator {
     public enum Style {
         case `default`
+        #if os(iOS)
         case bar
+        #endif
     }
 }
 #endif

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -138,7 +138,7 @@ extension WebImage {
     /// Associate a indicator when loading image with url
     /// - Parameter indicator: The indicator type, see `Indicator`
     public func indicator<T>(_ indicator: Indicator<T>) -> some View where T : View {
-        return IndicatorView(self, indicator: indicator, imageManager: imageManager)
+        return self.modifier(IndicatorViewModifier(imageManager: imageManager, indicator: indicator))
     }
     
     /// Associate a indicator when loading image with url, convenient method with block


### PR DESCRIPTION
Seems using View Modifier can simplify the dummy code, and it's more SwiftUI Style for users. (Since it's a view modifier method, it should use view modifier).

This PR also fix one issue of that `ProgressIndicator.Style.bar`, which is only available on iOS.