### PR TITLE
Using the intrinsicContentSize on wrapper container, try to fix the aspect ratio sizing issue

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -43,6 +43,19 @@ public class AnimatedImageViewWrapper : PlatformView {
     }
     #endif
     
+    public override var intrinsicContentSize: CGSize {
+        /// Used to fix SwiftUI layout issue when image view is aspectFit/aspectFill :)
+        /// The container will measure its own size with 1:1 firstly, then change image view size, which cause image view sizing smaller than expected
+        /// Instead, the container should firstly return its own size with image view's aspect ratio
+        let size = wrapped.intrinsicContentSize
+        if size.width > 0 && size.height > 0  {
+            let aspectRatio = size.height / size.width
+            return CGSize(width: 1, height: 1 * aspectRatio)
+        } else {
+            return super.intrinsicContentSize
+        }
+    }
+    
     public override init(frame frameRect: CGRect) {
         super.init(frame: frameRect)
         addSubview(wrapped)


### PR DESCRIPTION
Hope this is the final change ;)


Before fix:

![image](https://user-images.githubusercontent.com/6919743/67795157-ce163880-fab8-11e9-89a9-cbc6160cabf8.png)


After fix:

![image](https://user-images.githubusercontent.com/6919743/67795165-d0789280-fab8-11e9-9e12-91db389f54a7.png)


The after fix is what `Image` and `WebImage` behavior. So we should fix that to match them.
