### PR TITLE
Fix the issue that WebImage will stop download after first progressive loading image loaded

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -29,6 +29,7 @@ struct ContentView: View {
     "https://isparta.github.io/compare-webp/image/gif_webp/webp/2.webp",
     "https://nokiatech.github.io/heif/content/images/ski_jump_1440x960.heic",
     "https://nokiatech.github.io/heif/content/image_sequences/starfield_animation.heic",
+    "https://www.sample-videos.com/img/Sample-png-image-1mb.png",
     "https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png",
     "http://via.placeholder.com/200x200.jpg"]
     @State var animated: Bool = true // You can change between WebImage/AnimatedImage

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -12,6 +12,7 @@ import SDWebImage
 class ImageManager : ObservableObject {
     @Published var image: PlatformImage?
     @Published var isLoading: Bool = false
+    @Published var isIncremental: Bool = false
     @Published var progress: CGFloat = 0
     
     var manager = SDWebImageManager.shared
@@ -56,6 +57,7 @@ class ImageManager : ObservableObject {
             if let image = image {
                 self.image = image
             }
+            self.isIncremental = !finished
             if finished {
                 self.isLoading = false
                 self.progress = 1

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import SDWebImage
 
 public struct WebImage : View {
-    static var emptyImage = Image(platformImage: PlatformImage())
+    static var emptyImage = PlatformImage()
     
     var url: URL?
     var placeholder: Image?
@@ -46,7 +46,7 @@ public struct WebImage : View {
             let view = image
             return AnyView(view)
         } else {
-            var image = placeholder ?? WebImage.emptyImage
+            var image = placeholder ?? Image(platformImage: WebImage.emptyImage)
             image = configurations.reduce(image) { (previous, configuration) in
                 configuration(previous)
             }
@@ -57,7 +57,10 @@ public struct WebImage : View {
                 }
             }
             .onDisappear {
-                self.imageManager.cancel()
+                // When using prorgessive loading, the previous partial image will cause onDisappear. Filter this case
+                if self.imageManager.isLoading && !self.imageManager.isIncremental {
+                    self.imageManager.cancel()
+                }
             }
             return AnyView(view)
         }


### PR DESCRIPTION
Also fix the regression issue of #37 .
It can not hold a single View struct, becauese SwiftUI animation use the binding value to drive view refresh, it's not a class instance. We should put all the `Binding` generate View inside the body method.