### PR TITLE
Fix WebImage with indicator, when quick scroll without cache, may cause recursion

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -32,7 +32,7 @@ struct ContentView: View {
     "https://www.sample-videos.com/img/Sample-png-image-1mb.png",
     "https://nr-platform.s3.amazonaws.com/uploads/platform/published_extension/branding_icon/275/AmazonS3.png",
     "http://via.placeholder.com/200x200.jpg"]
-    @State var animated: Bool = true // You can change between WebImage/AnimatedImage
+    @State var animated: Bool = false // You can change between WebImage/AnimatedImage
     
     var body: some View {
         #if os(iOS) || os(tvOS)

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -12,11 +12,12 @@ import SDWebImage
 class ImageManager : ObservableObject {
     @Published var image: PlatformImage?
     @Published var isLoading: Bool = false
-    @Published var isIncremental: Bool = false
     @Published var progress: CGFloat = 0
     
     var manager = SDWebImageManager.shared
     weak var currentOperation: SDWebImageOperation? = nil
+    var isFinished: Bool = false
+    var isIncremental: Bool = false
     
     var url: URL?
     var options: SDWebImageOptions
@@ -35,7 +36,6 @@ class ImageManager : ObservableObject {
         if currentOperation != nil {
             return
         }
-        self.image = nil
         self.isLoading = true
         currentOperation = manager.loadImage(with: url, options: options, context: context, progress: { [weak self] (receivedSize, expectedSize, _) in
             guard let self = self else {
@@ -55,6 +55,13 @@ class ImageManager : ObservableObject {
             guard let self = self else {
                 return
             }
+            if let error = error as? SDWebImageError, error.code == .cancelled {
+                // Ignore user cancelled
+                // There are race condition when quick scroll
+                // Indicator modifier disapper and trigger `WebImage.body`
+                // So previous View struct call `onDisappear` and cancel the currentOperation
+                return
+            }
             if let image = image {
                 self.image = image
             }
@@ -63,6 +70,7 @@ class ImageManager : ObservableObject {
                 self.isLoading = false
                 self.progress = 1
                 if let image = image {
+                    self.isFinished = true
                     self.successBlock?(image, cacheType)
                 } else {
                     self.failureBlock?(error ?? NSError())

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -10,14 +10,14 @@ import SwiftUI
 import SDWebImage
 
 class ImageManager : ObservableObject {
-    @Published var image: PlatformImage?
-    @Published var isLoading: Bool = false
-    @Published var progress: CGFloat = 0
+    @Published var image: PlatformImage? // loaded image, note when progressive loading, this will published multiple times with different partial image
+    @Published var isLoading: Bool = false // whether network is loading or cache is querying
+    @Published var progress: CGFloat = 0 // network progress
     
     var manager = SDWebImageManager.shared
     weak var currentOperation: SDWebImageOperation? = nil
-    var isFinished: Bool = false
-    var isIncremental: Bool = false
+    var isFinished: Bool = false // true means request end, load() do nothing
+    var isIncremental: Bool = false // true means during incremental loading
     
     var url: URL?
     var options: SDWebImageOptions

--- a/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
@@ -32,7 +32,7 @@ struct IndicatorViewModifier<T> : ViewModifier where T : View {
     var indicator: Indicator<T>
     
     func body(content: Content) -> some View {
-        if !imageManager.isLoading {
+        if imageManager.isFinished {
             // Disable Indiactor
             return AnyView(content)
         } else {

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -52,7 +52,7 @@ public struct WebImage : View {
             }
             let view = image
             .onAppear {
-                if self.imageManager.image == nil {
+                if !self.imageManager.isFinished {
                     self.imageManager.load()
                 }
             }


### PR DESCRIPTION
See the comment for reason:

```
// There are race condition when quick scroll, because SwiftUI handle for that @Published property
// Indicator modifier code go into `if` condition and trigger `WebImage.body` (*)
// Previous View struct call `onDisappear` and cancel the currentOperation
// currentOperation then call error block, and isLoading = true again
// isLoading true again trigger another new indicator, go into `else` condition and `Indicator.builder`
// Current View struct loaded finished, call isLoading = true again
// goto (*)
```