### PR TITLE
Use the only ZStack one state for indicator, instead of removing that indicator view from hierarchy

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -16,7 +16,7 @@ class ImageManager : ObservableObject {
     
     var manager = SDWebImageManager.shared
     weak var currentOperation: SDWebImageOperation? = nil
-    var isFinished: Bool = false // true means request end, load() do nothing
+    var isSuccess: Bool = false // true means request for this URL is ended forever, load() do nothing
     var isIncremental: Bool = false // true means during incremental loading
     
     var url: URL?
@@ -70,7 +70,7 @@ class ImageManager : ObservableObject {
                 self.isLoading = false
                 self.progress = 1
                 if let image = image {
-                    self.isFinished = true
+                    self.isSuccess = true
                     self.successBlock?(image, cacheType)
                 } else {
                     self.failureBlock?(error ?? NSError())

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -11,8 +11,8 @@ import SDWebImage
 
 class ImageManager : ObservableObject {
     @Published var image: PlatformImage? // loaded image, note when progressive loading, this will published multiple times with different partial image
-    @Published var isLoading: Bool = false // whether network is loading or cache is querying
-    @Published var progress: CGFloat = 0 // network progress
+    @Published var isLoading: Bool = false // whether network is loading or cache is querying, should only be used for indicator binding
+    @Published var progress: CGFloat = 0 // network progress, should only be used for indicator binding
     
     var manager = SDWebImageManager.shared
     weak var currentOperation: SDWebImageOperation? = nil

--- a/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
@@ -32,16 +32,12 @@ struct IndicatorViewModifier<T> : ViewModifier where T : View {
     var indicator: Indicator<T>
     
     func body(content: Content) -> some View {
-        Group {
-            if imageManager.isFinished {
-                // Disable Indiactor
-                content
+        ZStack {
+            content
+            if imageManager.isLoading {
+                indicator.content($imageManager.isLoading, $imageManager.progress)
             } else {
-                // Enable indicator
-                ZStack {
-                    content
-                    indicator.content($imageManager.isLoading, $imageManager.progress)
-                }
+                indicator.content($imageManager.isLoading, $imageManager.progress).hidden()
             }
         }
     }

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -62,7 +62,7 @@ public struct WebImage : View {
                 .onDisappear {
                     guard self.cancelOnDisappear else { return }
                     // When using prorgessive loading, the previous partial image will cause onDisappear. Filter this case
-                    if self.imageManager.isLoading && !self.imageManager.isIncremental {
+                    if !self.imageManager.isFinished && !self.imageManager.isIncremental {
                         self.imageManager.cancel()
                     }
                 }

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -55,14 +55,14 @@ public struct WebImage : View {
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                 .onAppear {
                     guard self.retryOnAppear else { return }
-                    if !self.imageManager.isFinished {
+                    if !self.imageManager.isSuccess {
                         self.imageManager.load()
                     }
                 }
                 .onDisappear {
                     guard self.cancelOnDisappear else { return }
                     // When using prorgessive loading, the previous partial image will cause onDisappear. Filter this case
-                    if !self.imageManager.isFinished && !self.imageManager.isIncremental {
+                    if !self.imageManager.isSuccess && !self.imageManager.isIncremental {
                         self.imageManager.cancel()
                     }
                 }


### PR DESCRIPTION
Fix for annoying bugs because the fact:

> when writting the if else code with a Binding object, it will query the `WebImage`.body again.

This means, another new WebImage struct will be created, and receive a ImageManger.load (ImageManger is a class, which means they share the same state !). So the state mass up.

Using ZStack without changes will not cause the `WebImage` to be re-generaetd. This is the simplest solution.