### PR TITLE
Refactory the watchOS Animation solution using the SDAnimatedImagePlayer (~> 5.3.0)

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "SDWebImage/SDWebImage" ~> 5.1
+github "SDWebImage/SDWebImage" ~> 5.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "SDWebImage/SDWebImage" "5.2.3"
+github "SDWebImage/SDWebImage" "5.3.0"

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,11 +8,11 @@ PODS:
   - libwebp/mux (1.0.3):
     - libwebp/demux
   - libwebp/webp (1.0.3)
-  - SDWebImage (5.2.5):
-    - SDWebImage/Core (= 5.2.5)
-  - SDWebImage/Core (5.2.5)
-  - SDWebImageSwiftUI (0.6.2):
-    - SDWebImage (~> 5.1)
+  - SDWebImage (5.3.0):
+    - SDWebImage/Core (= 5.3.0)
+  - SDWebImage/Core (5.3.0)
+  - SDWebImageSwiftUI (0.7.0):
+    - SDWebImage (~> 5.3)
   - SDWebImageWebPCoder (0.2.5):
     - libwebp (~> 1.0)
     - SDWebImage/Core (~> 5.0)
@@ -33,8 +33,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   libwebp: 057912d6d0abfb6357d8bb05c0ea470301f5d61e
-  SDWebImage: 4eabf2fa6695c95c47724214417a9c036c965e4a
-  SDWebImageSwiftUI: 26a485e004cd64f5dde194bd97882aba962ab5b0
+  SDWebImage: f1afa74b86587c2c63f4e80dfd39b21e3c17b45b
+  SDWebImageSwiftUI: 72add2eb640bdadc856cdc30954528bffe8dfec0
   SDWebImageWebPCoder: 947093edd1349d820c40afbd9f42acb6cdecd987
 
 PODFILE CHECKSUM: 3fb06a5173225e197f3a4bf2be7e5586a693257a

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/SDWebImage/SDWebImage.git",
         "state": {
           "branch": null,
-          "revision": "39ecbe51de1455c56e877397b9838a7f8fafd71a",
-          "version": "5.2.2"
+          "revision": "48909c2a744d9c7d0350398fafc127945e367286",
+          "version": "5.3.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.1.0")
+        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.3.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/SDWebImageSwiftUI.podspec
+++ b/SDWebImageSwiftUI.podspec
@@ -29,6 +29,6 @@ Which aims to provide a better support for SwiftUI users.
   s.source_files = 'SDWebImageSwiftUI/Classes/**/*', 'SDWebImageSwiftUI/Module/*.h'
 
   s.frameworks = 'SwiftUI'
-  s.dependency 'SDWebImage', '~> 5.1'
+  s.dependency 'SDWebImage', '~> 5.3'
   s.swift_version = '5.1'
 end

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -221,11 +221,6 @@ public struct AnimatedImage : PlatformViewRepresentable {
     }
     
     func updateView(_ view: AnimatedImageViewWrapper, context: Context) {
-        // macOS SDAnimatedImageView.animates should initialize to true in advance before set image
-        #if os(macOS)
-        view.wrapped.animates = true
-        #endif
-        
         if let image = self.image {
             #if os(watchOS)
             view.wrapped.setImage(image)
@@ -243,7 +238,9 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
         
         #if os(macOS)
-        view.wrapped.animates = self.isAnimating
+        if self.isAnimating != view.wrapped.animates {
+            view.wrapped.animates = self.isAnimating
+        }
         #else
         if self.isAnimating != view.wrapped.isAnimating {
             if self.isAnimating {

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -330,10 +330,8 @@ public struct AnimatedImage : PlatformViewRepresentable {
         
         #if os(macOS)
         view.wrapped.imageScaling = contentMode
-        #elseif os(iOS) || os(tvOS)
+        #else
         view.wrapped.contentMode = contentMode
-        #elseif os(watchOS)
-        view.wrapped.setContentMode(contentMode)
         #endif
         
         // Animated Image does not support resizing mode and rendering mode

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -64,6 +64,10 @@ public struct AnimatedImage : PlatformViewRepresentable {
     var incrementalLoad: Bool?
     var maxBufferSize: UInt?
     var customLoopCount: Int?
+    var runLoopMode: RunLoop.Mode?
+    var pausable: Bool?
+    var clearBufferWhenStopped: Bool?
+    var playBackRate: Double?
     #if os(macOS) || os(iOS) || os(tvOS)
     // These configurations only useful for web image loading
     var indicator: SDWebImageIndicator?
@@ -467,12 +471,40 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
         #elseif os(watchOS)
         if let customLoopCount = self.customLoopCount {
-            view.wrapped.setAnimationRepeatCount(customLoopCount as NSNumber)
+            view.wrapped.animationRepeatCount = customLoopCount as NSNumber
         } else {
             // disable custom loop count
-            view.wrapped.setAnimationRepeatCount(nil)
+            view.wrapped.animationRepeatCount = nil
         }
         #endif
+        
+        // RunLoop Mode
+        if let runLoopMode = self.runLoopMode {
+            view.wrapped.runLoopMode = runLoopMode
+        } else {
+            view.wrapped.runLoopMode = .common
+        }
+        
+        // Pausable
+        if let pausable = self.pausable {
+            view.wrapped.resetFrameIndexWhenStopped = !pausable
+        } else {
+            view.wrapped.resetFrameIndexWhenStopped = false
+        }
+        
+        // Clear Buffer
+        if let clearBufferWhenStopped = self.clearBufferWhenStopped {
+            view.wrapped.clearBufferWhenStopped = clearBufferWhenStopped
+        } else {
+            view.wrapped.clearBufferWhenStopped = false
+        }
+        
+        // Playback Rate
+        if let playBackRate = self.playBackRate {
+            view.wrapped.playbackRate = playBackRate
+        } else {
+            view.wrapped.playbackRate = 1.0
+        }
     }
 }
 
@@ -623,6 +655,48 @@ extension AnimatedImage {
     public func incrementalLoad(_ incrementalLoad: Bool) -> AnimatedImage {
         var result = self
         result.incrementalLoad = incrementalLoad
+        return result
+    }
+    
+    /// The runLoopMode when animation is playing on. Defaults is `.common`
+    ///  You can specify a runloop mode to let it rendering.
+    /// - Note: This is useful for some cases, for example, always specify NSDefaultRunLoopMode, if you want to pause the animation when user scroll (for Mac user, drag the mouse or touchpad)
+    /// - Parameter runLoopMode: The runLoopMode for animation
+    public func runLoopMode(_ runLoopMode: RunLoop.Mode) -> AnimatedImage {
+        var result = self
+        result.runLoopMode = runLoopMode
+        return result
+    }
+    
+    /// Whether or not to pause the animation (keep current frame), instead of stop the animation (frame index reset to 0). When the `isAnimating` binding value changed to false.
+    /// Defaults is true.
+    /// - Note: For some of use case, you may want to reset the frame index to 0 when stop, but some other want to keep the current frame index.
+    /// - Parameter pausable: Whether or not to pause the animation instead of stop the animation.
+    public func pausable(_ pausable: Bool) -> AnimatedImage {
+        var result = self
+        result.pausable = pausable
+        return result
+    }
+    
+    /// Whether or not to clear frame buffer cache when stopped.
+    /// Note: This is useful when you want to limit the memory usage during frequently visibility changes (such as image view inside a list view, then push and pop)
+    /// - Parameter clearBufferWhenStopped: Whether or not to clear frame buffer cache when stopped.
+    public func clearBufferWhenStopped(_ clearBufferWhenStopped: Bool) -> AnimatedImage {
+        var result = self
+        result.clearBufferWhenStopped = clearBufferWhenStopped
+        return result
+    }
+    
+    /// Control the animation playback rate. Default is 1.0.
+    /// `1.0` means the normal speed.
+    /// `0.0` means stopping the animation.
+    /// `0.0-1.0` means the slow speed.
+    /// `> 1.0` means the fast speed.
+    /// `< 0.0` is not supported currently and stop animation. (may support reverse playback in the future)
+    /// - Parameter playBackRate: The animation playback rate.
+    public func playBackRate(_ playBackRate: Double) -> AnimatedImage {
+        var result = self
+        result.playBackRate = playBackRate
         return result
     }
 }

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -340,7 +340,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
         if let image = self.image, !image.sd_isAnimated, !image.conforms(to: SDAnimatedImageProtocol.self) {
             var image = image
             // ResizingMode
-            if let resizingMode = self.resizingMode {
+            if let resizingMode = self.resizingMode, capInsets != EdgeInsets() {
                 #if os(macOS)
                 let capInsets = NSEdgeInsets(top: self.capInsets.top, left: self.capInsets.leading, bottom: self.capInsets.bottom, right: self.capInsets.trailing)
                 #else

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -60,7 +60,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
     var customLoopCount: Int?
     var runLoopMode: RunLoop.Mode?
     var pausable: Bool?
-    var clearBufferWhenStopped: Bool?
+    var purgeable: Bool?
     var playBackRate: Double?
     #if os(macOS) || os(iOS) || os(tvOS)
     // These configurations only useful for web image loading
@@ -481,8 +481,8 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
         
         // Clear Buffer
-        if let clearBufferWhenStopped = self.clearBufferWhenStopped {
-            view.wrapped.clearBufferWhenStopped = clearBufferWhenStopped
+        if let purgeable = self.purgeable {
+            view.wrapped.clearBufferWhenStopped = purgeable
         } else {
             view.wrapped.clearBufferWhenStopped = false
         }
@@ -656,8 +656,7 @@ extension AnimatedImage {
         return result
     }
     
-    /// Whether or not to pause the animation (keep current frame), instead of stop the animation (frame index reset to 0). When the `isAnimating` binding value changed to false.
-    /// Defaults is true.
+    /// Whether or not to pause the animation (keep current frame), instead of stop the animation (frame index reset to 0). When `isAnimating` binding value changed to false. Defaults is true.
     /// - Note: For some of use case, you may want to reset the frame index to 0 when stop, but some other want to keep the current frame index.
     /// - Parameter pausable: Whether or not to pause the animation instead of stop the animation.
     public func pausable(_ pausable: Bool) -> AnimatedImage {
@@ -666,12 +665,12 @@ extension AnimatedImage {
         return result
     }
     
-    /// Whether or not to clear frame buffer cache when stopped.
+    /// Whether or not to clear frame buffer cache when stopped. Defaults is false.
     /// Note: This is useful when you want to limit the memory usage during frequently visibility changes (such as image view inside a list view, then push and pop)
-    /// - Parameter clearBufferWhenStopped: Whether or not to clear frame buffer cache when stopped.
-    public func clearBufferWhenStopped(_ clearBufferWhenStopped: Bool) -> AnimatedImage {
+    /// - Parameter purgeable: Whether or not to clear frame buffer cache when stopped.
+    public func purgeable(_ purgeable: Bool) -> AnimatedImage {
         var result = self
-        result.clearBufferWhenStopped = clearBufferWhenStopped
+        result.purgeable = purgeable
         return result
     }
     

--- a/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.h
+++ b/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.h
@@ -19,6 +19,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init WK_AVAILABLE_WATCHOS_ONLY(6.0);
 - (void)setContentMode:(SDImageScaleMode)contentMode;
 - (void)setAnimationRepeatCount:(nullable NSNumber *)repeatCount;
+- (void)setRunLoopMode:(nonnull NSRunLoopMode)runLoopMode;
+- (void)setPlaybackRate:(double)playbackRate;
+
+/// Trigger the animation check when view appears/disappears
 - (void)updateAnimation;
 
 @end

--- a/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.h
+++ b/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDAnimatedImageInterface : WKInterfaceImage
 
 @property (nonatomic, assign, getter=isAnimating, readonly) BOOL animating;
+@property (nonatomic, assign) SDImageScaleMode contentMode;
 @property (nonatomic, strong, nullable) NSNumber *animationRepeatCount;
 @property (nonatomic, copy) NSRunLoopMode runLoopMode;
 @property (nonatomic, assign) BOOL resetFrameIndexWhenStopped;
@@ -22,10 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) double playbackRate;
 
 - (instancetype)init WK_AVAILABLE_WATCHOS_ONLY(6.0);
-
-/// Set the content mode for image
-/// @param contentMode The contrent mode
-- (void)setContentMode:(SDImageScaleMode)contentMode;
 
 /// Trigger the animation check when view appears/disappears
 - (void)updateAnimation;

--- a/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.h
+++ b/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.h
@@ -15,12 +15,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SDAnimatedImageInterface : WKInterfaceImage
 
 @property (nonatomic, assign, getter=isAnimating, readonly) BOOL animating;
+@property (nonatomic, strong, nullable) NSNumber *animationRepeatCount;
+@property (nonatomic, copy) NSRunLoopMode runLoopMode;
+@property (nonatomic, assign) BOOL resetFrameIndexWhenStopped;
+@property (nonatomic, assign) BOOL clearBufferWhenStopped;
+@property (nonatomic, assign) double playbackRate;
 
 - (instancetype)init WK_AVAILABLE_WATCHOS_ONLY(6.0);
+
+/// Set the content mode for image
+/// @param contentMode The contrent mode
 - (void)setContentMode:(SDImageScaleMode)contentMode;
-- (void)setAnimationRepeatCount:(nullable NSNumber *)repeatCount;
-- (void)setRunLoopMode:(nonnull NSRunLoopMode)runLoopMode;
-- (void)setPlaybackRate:(double)playbackRate;
 
 /// Trigger the animation check when view appears/disappears
 - (void)updateAnimation;

--- a/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.m
+++ b/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.m
@@ -196,15 +196,6 @@ static UIImage * SharedEmptyImage(void) {
     }
 }
 
-- (void)startAnimatingWithImagesInRange:(NSRange)imageRange duration:(NSTimeInterval)duration repeatCount:(NSInteger)repeatCount {
-    self.animating = YES;
-    if (self.player) {
-        [self.player startPlaying];
-    } else if (_image.images.count > 0) {
-        [super startAnimatingWithImagesInRange:imageRange duration:duration repeatCount:repeatCount];
-    }
-}
-
 - (void)stopAnimating {
     self.animating = NO;
     if (self.player) {

--- a/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.m
+++ b/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.m
@@ -56,6 +56,8 @@
 @property (nonatomic, assign, readwrite) NSUInteger currentLoopCount;
 @property (nonatomic, strong) NSNumber *animationRepeatCount;
 @property (nonatomic, assign) BOOL shouldAnimate;
+@property (nonatomic, copy) NSRunLoopMode runLoopMode;
+@property (nonatomic, assign) double playbackRate;
 @property (nonatomic,strong) SDAnimatedImagePlayer *player; // The animation player.
 @property (nonatomic) id<CALayerProtocol> imageViewLayer; // The actual rendering layer.
 
@@ -68,6 +70,10 @@
     NSString *UUID = [NSUUID UUID].UUIDString;
     NSString *property = [NSString stringWithFormat:@"%@_%@", cls, UUID];
     self = [self _initForDynamicCreationWithInterfaceProperty:property];
+    if (self) {
+        self.runLoopMode = NSRunLoopCommonModes;
+        self.playbackRate = 1.0;
+    }
     return self;
 }
 
@@ -125,11 +131,11 @@
             self.player.totalLoopCount = self.animationRepeatCount.unsignedIntegerValue;
         }
         
-//        // RunLoop Mode
-//        self.player.runLoopMode = self.runLoopMode;
-//
-//        // Play Rate
-//        self.player.playbackRate = self.playbackRate;
+        // RunLoop Mode
+        self.player.runLoopMode = self.runLoopMode;
+
+        // Play Rate
+        self.player.playbackRate = self.playbackRate;
         
         // Setup handler
         __weak typeof(self) wself = self;

--- a/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.m
+++ b/SDWebImageSwiftUI/Classes/ObjC/SDAnimatedImageInterface.m
@@ -174,7 +174,7 @@ static UIImage * SharedEmptyImage(void) {
 
 // on watchOS, it's the native imageView itself's layer
 - (id<CALayerProtocol>)imageViewLayer {
-    return [[self _interfaceView] layer];
+    return [self _interfaceView].layer;
 }
 
 - (void)updateShouldAnimate
@@ -214,6 +214,10 @@ static UIImage * SharedEmptyImage(void) {
 
 - (void)setContentMode:(SDImageScaleMode)contentMode {
     [self _interfaceView].contentMode = contentMode;
+}
+
+- (SDImageScaleMode)contentMode {
+    return [self _interfaceView].contentMode;
 }
 
 @end


### PR DESCRIPTION
For Animated Player, See SDWebImage 5.3.0 feature: https://github.com/SDWebImage/SDWebImage/releases/tag/5.3.0

This PR refactoring the watchOS implementation, without the Image/IO Animation API (Which can only use GIF). Supports animated webp as well.

This PR add some upstream control options like playback rate on AnimatedImage.

Also, this PR fix watchOS current incompatible issues with watchOS 6.1. (Previously works well on watchOS 6.0)