### PR TITLE
Fix the placeholder API viewBuilder args to match the documentation

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -8,14 +8,6 @@
 
 import SwiftUI
 import SDWebImage
-#if canImport(SDWebImageSwiftUIObjC)
-import SDWebImageSwiftUIObjC
-#endif
-
-// Convenient
-#if os(watchOS)
-public typealias AnimatedImageViewWrapper = SDAnimatedImageInterfaceWrapper
-#endif
 
 /// A coordinator object used for `AnimatedImage`native view  bridge for UIKit/AppKit/WatchKit.
 public final class AnimatedImageCoordinator: NSObject {

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -8,6 +8,14 @@
 
 import Foundation
 import SDWebImage
+#if canImport(SDWebImageSwiftUIObjC)
+import SDWebImageSwiftUIObjC
+#endif
+
+#if os(watchOS)
+/// Use wrapper to solve the `WKInterfaceImage` aspect issue (SwiftUI's Bug)
+public typealias AnimatedImageViewWrapper = SDAnimatedImageInterfaceWrapper
+#endif
 
 #if !os(watchOS)
 

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -144,7 +144,7 @@ extension WebImage {
     /// Associate a placeholder when loading image with url
     /// - note: The differences between Placeholder and Indicator, is that placeholder does not supports animation, and return type is different
     /// - Parameter content: A view that describes the placeholder.
-    public func placeholder<T>(@ViewBuilder _ content: () -> T) -> WebImage where T : View {
+    public func placeholder<T>(@ViewBuilder content: () -> T) -> WebImage where T : View {
         var result = self
         result.placeholder = AnyView(content())
         return result


### PR DESCRIPTION
Which should use `placeholder<T>(@ViewBuilder content: () -> T)`, not `placeholder<T>(@ViewBuilder _: () -> T)`