### PR TITLE
Add support to pass the `.customManager` context option to custom SDWebImageManager instance

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/AppDelegate.swift
+++ b/Example/SDWebImageSwiftUIDemo/AppDelegate.swift
@@ -25,13 +25,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         SDImageCodersManager.shared.addCoder(SDImagePDFCoder.shared)
         // Dynamic check to support both WebImage/AnimatedImage
         SDWebImageManager.shared.optionsProcessor = SDWebImageOptionsProcessor { url, options, context in
-            var context = context ?? [:]
-            if let _ = context[.animatedImageClass] as? SDAnimatedImageProtocol {
+            var context = context
+            if let _ = context?[.animatedImageClass] as? SDAnimatedImageProtocol {
                 // AnimatedImage supports vector rendering
             } else {
                 // WebImage supports bitmap rendering only
-                context[.svgPrefersBitmap] = true
-                context[.pdfPrefersBitmap] = true
+                context?[.svgPrefersBitmap] = true
+                context?[.pdfPrefersBitmap] = true
             }
             return SDWebImageOptionsResult(options: options, context: context)
         }

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -15,7 +15,7 @@ class ImageManager : ObservableObject {
     @Published var isLoading: Bool = false // whether network is loading or cache is querying, should only be used for indicator binding
     @Published var progress: CGFloat = 0 // network progress, should only be used for indicator binding
     
-    var manager = SDWebImageManager.shared
+    var manager: SDWebImageManager
     weak var currentOperation: SDWebImageOperation? = nil
     var isSuccess: Bool = false // true means request for this URL is ended forever, load() do nothing
     var isIncremental: Bool = false // true means during incremental loading
@@ -31,6 +31,11 @@ class ImageManager : ObservableObject {
         self.url = url
         self.options = options
         self.context = context
+        if let manager = context?[.customManager] as? SDWebImageManager {
+            self.manager = manager
+        } else {
+            self.manager = .shared
+        }
     }
     
     func load() {


### PR DESCRIPTION
This fix #70 