### PR TITLE
Using the isAnimating arg, instead of protocol extention method to control the `WebImage`'s animation supports

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/AppDelegate.swift
+++ b/Example/SDWebImageSwiftUIDemo/AppDelegate.swift
@@ -26,7 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Dynamic check to support both WebImage/AnimatedImage
         SDWebImageManager.shared.optionsProcessor = SDWebImageOptionsProcessor { url, options, context in
             var context = context
-            if let _ = context?[.animatedImageClass] as? SDAnimatedImageProtocol {
+            if let _ = context?[.animatedImageClass] as? SDAnimatedImage.Type {
                 // AnimatedImage supports vector rendering
             } else {
                 // WebImage supports bitmap rendering only

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -105,9 +105,8 @@ struct ContentView: View {
                             .scaledToFit()
                             .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
                             #else
-                            WebImage(url: URL(string:url))
+                            WebImage(url: URL(string:url), isAnimating: self.$animated)
                             .resizable()
-                            .animated()
                             .indicator { _, _ in
                                 ActivityBar()
                                 .foregroundColor(Color.white)

--- a/Example/SDWebImageSwiftUIDemo/DetailView.swift
+++ b/Example/SDWebImageSwiftUIDemo/DetailView.swift
@@ -95,9 +95,8 @@ struct DetailView: View {
                 .resizable()
                 .scaledToFit()
                 #else
-                WebImage(url: URL(string:url), options: [.progressiveLoad])
+                WebImage(url: URL(string:url), options: [.progressiveLoad], isAnimating: $isAnimating)
                 .resizable()
-                .animated(isAnimating)
                 .indicator { isAnimating, progress in
                     ProgressBar(value: progress)
                     .foregroundColor(.blue)

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -66,11 +66,11 @@ final class AnimatedImageLayout : ObservableObject {
 final class AnimatedImageConfiguration: ObservableObject {
     var incrementalLoad: Bool?
     var maxBufferSize: UInt?
-    var customLoopCount: Int?
+    var customLoopCount: UInt?
     var runLoopMode: RunLoop.Mode?
     var pausable: Bool?
     var purgeable: Bool?
-    var playBackRate: Double?
+    var playbackRate: Double?
     // These configurations only useful for web image loading
     var indicator: SDWebImageIndicator?
     var transition: SDWebImageTransition?
@@ -415,7 +415,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
         // CustomLoopCount
         if let customLoopCount = imageConfiguration.customLoopCount {
             view.wrapped.shouldCustomLoopCount = true
-            view.wrapped.animationRepeatCount = customLoopCount
+            view.wrapped.animationRepeatCount = Int(customLoopCount)
         } else {
             // disable custom loop count
             view.wrapped.shouldCustomLoopCount = false
@@ -443,8 +443,8 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
         
         // Playback Rate
-        if let playBackRate = imageConfiguration.playBackRate {
-            view.wrapped.playbackRate = playBackRate
+        if let playbackRate = imageConfiguration.playbackRate {
+            view.wrapped.playbackRate = playbackRate
         } else {
             view.wrapped.playbackRate = 1.0
         }
@@ -557,7 +557,7 @@ extension AnimatedImage {
     /// Total loop count for animated image rendering. Defaults to nil.
     /// - Note: Pass nil to disable customization, use the image itself loop count (`animatedImageLoopCount`) instead
     /// - Parameter loopCount: The animation loop count
-    public func customLoopCount(_ loopCount: Int?) -> AnimatedImage {
+    public func customLoopCount(_ loopCount: UInt?) -> AnimatedImage {
         self.imageConfiguration.customLoopCount = loopCount
         return self
     }
@@ -613,9 +613,9 @@ extension AnimatedImage {
     /// `0.0-1.0` means the slow speed.
     /// `> 1.0` means the fast speed.
     /// `< 0.0` is not supported currently and stop animation. (may support reverse playback in the future)
-    /// - Parameter playBackRate: The animation playback rate.
-    public func playBackRate(_ playBackRate: Double) -> AnimatedImage {
-        self.imageConfiguration.playBackRate = playBackRate
+    /// - Parameter playbackRate: The animation playback rate.
+    public func playbackRate(_ playbackRate: Double) -> AnimatedImage {
+        self.imageConfiguration.playbackRate = playbackRate
         return self
     }
 }

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -28,7 +28,6 @@ public struct WebImage : View {
     @State var currentFrame: PlatformImage? = nil
     @State var imagePlayer: SDAnimatedImagePlayer? = nil
     
-    var incrementalLoad: Bool = true
     var maxBufferSize: UInt?
     var customLoopCount: UInt?
     var runLoopMode: RunLoop.Mode = .common
@@ -67,7 +66,7 @@ public struct WebImage : View {
     public var body: some View {
         Group {
             if imageManager.image != nil {
-                if isAnimating {
+                if isAnimating && !self.imageManager.isIncremental {
                     if currentFrame != nil {
                         configurations.reduce(Image(platformImage: currentFrame!)) { (previous, configuration) in
                             configuration(previous)
@@ -311,16 +310,6 @@ extension WebImage {
     public func maxBufferSize(_ bufferSize: UInt?) -> WebImage {
         var result = self
         result.maxBufferSize = bufferSize
-        return result
-    }
-    
-    /// Whehter or not to enable incremental image load for animated image. See `SDAnimatedImageView` for detailed explanation for this.
-    /// - Note: If you are confused about this description, open Chrome browser to view some large GIF images with low network speed to see the animation behavior.
-    /// Default is true. Set to false to only render the static poster for incremental animated image.
-    /// - Parameter incrementalLoad: Whether or not to incremental load
-    public func incrementalLoad(_ incrementalLoad: Bool) -> WebImage {
-        var result = self
-        result.incrementalLoad = incrementalLoad
         return result
     }
     


### PR DESCRIPTION
This allows the binding control for animation as well.

This is a break API changes ready for milestone 1.0.0.