### PR TITLE
Fix AnimatedImage resizable behavior, now `resizable` is required to make it resizable, or it will preserve image pixel size

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ var body: some View {
         .onSuccess { image, cacheType in
             // Success
         }
-        .resizable() // Resizable like SwiftUI.Image
+        .resizable() // Resizable like SwiftUI.Image, you must use this modifier or the view will use the image bitmap size
         .placeholder(Image(systemName: "photo")) // Placeholder Image
         // Supports ViewBuilder as well
         .placeholder {
@@ -141,7 +141,8 @@ Note: From v0.9.0, `WebImage` supports animated image as well! You can use `.ani
 
 ```swift
 var body: some View {
-    WebImage(url: URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"), isAnimating: $isAnimating)) // Animation Control in 1.0.0 (for 0.x version, use `.animated()` modifier)
+    WebImage(url: URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"), isAnimating: $isAnimating)) // Animation Control in 1.0.0, supports dynamic changes
+    // The initial value of binding should be true (or you can use `.animatedImageClass` context option and pass `SDAnimatedImage`)
     .customLoopCount(1) // Custom loop count
     .playbackRate(2.0) // Playback speed rate
     // In 1.0.0, `WebImage` supports advanced control just like `AnimatedImage`, but without the progressive animation support
@@ -166,11 +167,11 @@ var body: some View {
         .onFailure { error in
             // Error
         }
-        .resizable() // Actually this is not needed unlike SwiftUI.Image
+        .resizable() // Resizable like SwiftUI.Image, you must use this modifier or the view will use the image bitmap size
         .placeholder(UIImage(systemName: "photo")) // Placeholder Image
         .indicator(SDWebImageActivityIndicator.medium) // Activity Indicator
         .transition(.fade) // Fade Transition
-        .scaledToFit() // Attention to call it on AnimatedImage, but not `some View` after View Modifier
+        .scaledToFit() // Attention to call it on AnimatedImage, but not `some View` after View Modifier (Swift Protocol Extension method is static dispatched)
         
         // Data
         AnimatedImage(data: try! Data(contentsOf: URL(fileURLWithPath: "/tmp/foo.webp")))

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -318,6 +318,11 @@ public struct AnimatedImage : PlatformViewRepresentable {
         view.wrapped.contentMode = contentMode
         #endif
         
+        // Resizable
+        if let _ = imageLayout.resizingMode {
+            view.resizable = true
+        }
+        
         // Animated Image does not support resizing mode and rendering mode
         if let image = view.wrapped.image, !image.sd_isAnimated, !image.conforms(to: SDAnimatedImageProtocol.self) {
             var image = image

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -199,7 +199,11 @@ public struct AnimatedImage : PlatformViewRepresentable {
             // This is a hack because of Xcode 11.3 bug, the @Published does not trigger another `updateUIView` call
             // Here I have to use UIKit API to triger the same effect (the window change implicitly cause re-render)
             if let hostingView = AnimatedImage.findHostingView(from: view) {
+                #if os(macOS)
+                hostingView.viewDidMoveToWindow()
+                #else
                 hostingView.didMoveToWindow()
+                #endif
             }
             if let image = image {
                 self.imageHandler.successBlock?(image, cacheType)

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -17,6 +17,7 @@ public class AnimatedImageViewWrapper : PlatformView {
     var wrapped = SDAnimatedImageView()
     var interpolationQuality = CGInterpolationQuality.default
     var shouldAntialias = false
+    var resizable = false
     
     override public func draw(_ rect: CGRect) {
         #if os(macOS)
@@ -49,10 +50,15 @@ public class AnimatedImageViewWrapper : PlatformView {
         /// The container will measure its own size with 1:1 firstly, then change image view size, which cause image view sizing smaller than expected
         /// Instead, the container should firstly return its own size with image view's aspect ratio
         let size = wrapped.intrinsicContentSize
-        if size.width > 0 && size.height > 0  {
-            return size
+        if resizable {
+            if size.width > 0 && size.height > 0  {
+                return size
+            } else {
+                return super.intrinsicContentSize
+            }
         } else {
-            return super.intrinsicContentSize
+            /// Not resizable, always use image size, like SwiftUI.Image
+            return size
         }
     }
     

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -46,19 +46,12 @@ public class AnimatedImageViewWrapper : PlatformView {
     #endif
     
     public override var intrinsicContentSize: CGSize {
-        /// Used to fix SwiftUI layout issue when image view is aspectFit/aspectFill :)
-        /// The container will measure its own size with 1:1 firstly, then change image view size, which cause image view sizing smaller than expected
-        /// Instead, the container should firstly return its own size with image view's aspect ratio
-        let size = wrapped.intrinsicContentSize
+        /// Match the behavior of SwiftUI.Image, only when image is resizable, use the super implementation to calculate size
         if resizable {
-            if size.width > 0 && size.height > 0  {
-                return size
-            } else {
-                return super.intrinsicContentSize
-            }
+            return super.intrinsicContentSize
         } else {
             /// Not resizable, always use image size, like SwiftUI.Image
-            return size
+            return wrapped.intrinsicContentSize
         }
     }
     

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -50,8 +50,7 @@ public class AnimatedImageViewWrapper : PlatformView {
         /// Instead, the container should firstly return its own size with image view's aspect ratio
         let size = wrapped.intrinsicContentSize
         if size.width > 0 && size.height > 0  {
-            let aspectRatio = size.height / size.width
-            return CGSize(width: 1, height: 1 * aspectRatio)
+            return size
         } else {
             return super.intrinsicContentSize
         }


### PR DESCRIPTION
This match the behavior of `WebImage` and `SwiftUI.Image`