### PR TITLE
Release 1.0

### DIFF
--- a/Example/SDWebImageSwiftUIDemo-macOS/AppDelegate.swift
+++ b/Example/SDWebImageSwiftUIDemo-macOS/AppDelegate.swift
@@ -45,8 +45,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 options.insert(.avoidDecodeImage)
             } else {
                 // WebImage supports bitmap rendering only
-                context?[.svgPrefersBitmap] = true
-                context?[.pdfPrefersBitmap] = true
+                context?[.imageThumbnailPixelSize] = CGSize.zero
             }
             return SDWebImageOptionsResult(options: options, context: context)
         }

--- a/Example/SDWebImageSwiftUIDemo-tvOS/AppDelegate.swift
+++ b/Example/SDWebImageSwiftUIDemo-tvOS/AppDelegate.swift
@@ -53,8 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 options.insert(.avoidDecodeImage)
             } else {
                 // WebImage supports bitmap rendering only
-                context?[.svgPrefersBitmap] = true
-                context?[.pdfPrefersBitmap] = true
+                context?[.imageThumbnailPixelSize] = CGSize.zero
             }
             return SDWebImageOptionsResult(options: options, context: context)
         }

--- a/Example/SDWebImageSwiftUIDemo-watchOS WatchKit Extension/ExtensionDelegate.swift
+++ b/Example/SDWebImageSwiftUIDemo-watchOS WatchKit Extension/ExtensionDelegate.swift
@@ -24,8 +24,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         SDWebImageManager.shared.optionsProcessor = SDWebImageOptionsProcessor { url, options, context in
             var context = context
             // WebImage supports bitmap rendering only
-            context?[.svgPrefersBitmap] = true
-            context?[.pdfPrefersBitmap] = true
+            context?[.imageThumbnailPixelSize] = CGSize.zero
             return SDWebImageOptionsResult(options: options, context: context)
         }
     }

--- a/Example/SDWebImageSwiftUIDemo/AppDelegate.swift
+++ b/Example/SDWebImageSwiftUIDemo/AppDelegate.swift
@@ -32,8 +32,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 options.insert(.avoidDecodeImage)
             } else {
                 // WebImage supports bitmap rendering only
-                context?[.svgPrefersBitmap] = true
-                context?[.pdfPrefersBitmap] = true
+                context?[.imageThumbnailPixelSize] = CGSize.zero
             }
             return SDWebImageOptionsResult(options: options, context: context)
         }

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -12,8 +12,10 @@ import SDWebImageSwiftUI
 
 class UserSettings: ObservableObject {
     // Some environment configuration
+    #if os(tvOS)
     @Published var editMode: EditMode = .inactive
     @Published var zoomed: Bool = false
+    #endif
 }
 
 #if os(watchOS)

--- a/Example/SDWebImageSwiftUIDemo/Espera.swift
+++ b/Example/SDWebImageSwiftUIDemo/Espera.swift
@@ -194,10 +194,10 @@ public struct StretchLoadingView: View {
 
 public struct StretchProgressView: View {
     
-    @Binding public var progress: CGFloat
+    @Binding public var progress: Double
     
     public var body: some View {
-        StretchyShape(progress: Double(progress), mode: .stretchy)
+        StretchyShape(progress: progress, mode: .stretchy)
         .frame(width: 140, height: 10)
     }
 }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ SDWebImageSwiftUI is a SwiftUI image loading framework, which based on [SDWebIma
 
 It brings all your favorite features from SDWebImage, like async image loading, memory/disk caching, animated image playback and performances.
 
+The framework provide the different View structs, which API match the SwiftUI framework guideline. If you're familiar with `Image`, you'll find it easy to use `WebImage` and `AnimatedImage`.
+
 ## Features
 
 Since SDWebImageSwiftUI is built on top of SDWebImage, it provide both the out-of-box features as well as advanced powerful features you may want in real world Apps. Check our [Wiki](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage) when you need:
@@ -34,9 +36,9 @@ Besides all these features, we do optimization for SwiftUI, like Binding, View M
 
 This framework is under heavily development, it's recommended to use [the latest release](https://github.com/SDWebImage/SDWebImageSwiftUI/releases) as much as possible (including SDWebImage dependency).
 
-The v1.0.0 version is now **on beta**, all the previous users are recommended to use, test and report issues. We need you feedback to drive the future development. The official version may released in February.
+The v1.0.0 version is now **released**, which provide all the function above, with the stable API, fully documentation and unit test.
 
-The v1.0.0 version provide all the function above, with the stable API, fully documentation and unit test. This framework follows [Semantic Versioning](https://semver.org/).
+This framework follows [Semantic Versioning](https://semver.org/). Each source-break API changes will bump to a major version.
 
 ## Contribution
 
@@ -78,10 +80,6 @@ SDWebImageSwiftUI is available through [Swift Package Manager](https://swift.org
 
 For App integration, you should using Xcode 11 or higher, to add this package to your App target. To do this, check [Adding Package Dependencies to Your App](https://developer.apple.com/documentation/xcode/adding_package_dependencies_to_your_app?language=objc) about the step by step tutorial using Xcode.
 
-Note for any pre-release version like 1.0.0 beta, you should use the `Exact` dependency, or the `Range` dependency. Using `Up to next Major` does not resolve the pre-release version.
-
-![](https://user-images.githubusercontent.com/6919743/73805686-5451c180-4802-11ea-9b72-d082ad315bfc.png)
-
 + For downstream framework
 
 For downstream framework author, you should create a `Package.swift` file into your git repo, then add the following line to mark your framework dependent our SDWebImageSwiftUI.
@@ -90,16 +88,6 @@ For downstream framework author, you should create a `Package.swift` file into y
 let package = Package(
     dependencies: [
         .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI.git", from: "1.0")
-    ],
-)
-```
-
-Note for any pre-release version like 1.0.0 beta, you should use the SwiftPM [prereleaseIdentifiers](https://developer.apple.com/documentation/swift_packages/version/2878264-prereleaseidentifiers) API to specify it. The default `from:` does not resolve the pre-release version.
-
-```swift
-let package = Package(
-    dependencies: [
-        .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI.git", from: Version(1, 0, 0, prereleaseIdentifiers: ["-beta"])))
     ],
 )
 ```
@@ -113,7 +101,7 @@ let package = Package(
 - [x] Supports success/failure/progress changes event for custom handling
 - [x] Supports indicator with activity/progress indicator and customization
 - [x] Supports built-in animation and transition, powered by SwiftUI
-- [x] Supports animated image as well! (from v0.9.0)
+- [x] Supports animated image as well!
 
 ```swift
 var body: some View {
@@ -135,17 +123,17 @@ var body: some View {
 }
 ```
 
-Note: This `WebImage` using `Image` for internal implementation, which is the best compatible for SwiftUI layout and animation system. In previous version, `WebImage` supports static image format only, because unlike `UIImageView` in UIKit, SwiftUI's `Image` does not support animated image or vector image.
+Note: This `WebImage` using `Image` for internal implementation, which is the best compatible for SwiftUI layout and animation system. But unlike SwiftUI's `Image` which does not support animated image or vector image, `WebImage` supports animated image as well.
 
-Note: From v0.9.0, `WebImage` supports animated image as well! You can use `.animated()` to start animation. This is done by using the native SwiftUI rendering system and SDWebImage's powerful [Animated Player](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#animated-player-530). The `WebImage` animated image provide common use case, so it's still recommend to use `AnimatedImage` for advanced controls like progressive animation rendering.
+Note: The `WebImage` animation provide common use case, so it's still recommend to use `AnimatedImage` for advanced controls like progressive animation rendering.
 
 ```swift
 var body: some View {
-    WebImage(url: URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"), isAnimating: $isAnimating)) // Animation Control in 1.0.0, supports dynamic changes
+    WebImage(url: URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"), isAnimating: $isAnimating)) // Animation Control, supports dynamic changes
     // The initial value of binding should be true (or you can use `.animatedImageClass` context option and pass `SDAnimatedImage`)
     .customLoopCount(1) // Custom loop count
     .playbackRate(2.0) // Playback speed rate
-    // In 1.0.0, `WebImage` supports advanced control just like `AnimatedImage`, but without the progressive animation support
+    // `WebImage` supports advanced control just like `AnimatedImage`, but without the progressive animation support
 }
 ```
 
@@ -190,17 +178,13 @@ var body: some View {
 
 Note: `AnimatedImage` supports both image url or image data for animated image format. Which use the SDWebImage's [Animated ImageView](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#animated-image-50) for internal implementation. Pay attention that since this base on UIKit/AppKit representable, some advanced SwiftUI layout and animation system may not work as expected. You may need UIKit/AppKit and Core Animation to modify the native view.
 
-Note: From v0.9.0, `AnimatedImage` on watchOS drop the supports on watchOS, because of using hacks and private APIs. For watchOS user, choose `WebImage` instead.
-
-Note: From v0.8.0, `AnimatedImage` on watchOS support all features the same as iOS/tvOS/macOS, including Animated WebP rendering, runloop mode, pausable, purgeable, playback rate, etc. It use the SDWebImage's [Animated Player](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#animated-player-530), which is the same backend engine for iOS/tvOS/macOS's Animated ImageView.
-
 ### Which View to choose
 
 Why we have two different View types here, is because of current SwiftUI limit. But we're aimed to provide best solution for all use cases.
 
 If you don't need animated image, prefer to use `WebImage` firstly. Which behaves the seamless as built-in SwiftUI View. If SwiftUI works, it works.
 
-If you need simple animated image, use v0.9.0 above with `WebImage`. Which provide the basic animated image support. But it does not support progressive animation rendering, playback rate, etc.
+If you need simple animated image, use `WebImage`. Which provide the basic animated image support. But it does not support progressive animation rendering, playback rate, etc.
 
 If you need powerful animated image, `AnimatedImage` is the one to choose. Remember it supports static image as well, you don't need to check the format, just use as it.
 
@@ -289,25 +273,55 @@ NavigationView {
 
 #### Using for backward deployment and weak linking SwiftUI
 
-SDWebImageSwiftUI from v0.10.0, supports to use when your App Target has a deployment target version less than iOS 13/macOS 10.15/tvOS 13/watchOS 6. Which will weak linking of SwiftUI(Combine) to allows writing code with available check at runtime.
+SDWebImageSwiftUI supports to use when your App Target has a deployment target version less than iOS 13/macOS 10.15/tvOS 13/watchOS 6. Which will weak linking of SwiftUI(Combine) to allows writing code with available check at runtime.
 
 To use backward deployment, you have to do the follow things:
 
-+ Add `-weak_framework SwiftUI -weak_framework Combine` in your App Target's `Other Linker Flags` build setting
+##### Add weak linking framework
 
-You should notice that all the third party SwiftUI frameworks should have this build setting as well, not only just SDWebImageSwiftUI (we already added in v0.10.0). Or when running on iOS 12 device, it will trigger the runtime dyld error on startup.
+Add `-weak_framework SwiftUI -weak_framework Combine` in your App Target's `Other Linker Flags` build setting. You can also do this using Xcode's `Optional Framework` checkbox, there have the same effect.
 
-+ Use CocoaPods or Carthage (SwiftPM does not support weak linking nor backward deployment currently)
+You should notice that all the third party SwiftUI frameworks should have this build setting as well, not only just SDWebImageSwiftUI. Or when running on iOS 12 device, it will trigger the runtime dyld error on startup.
 
-For Carthage user, the built binary framework will use [Library Evolution](https://swift.org/blog/abi-stability-and-more/) to support for backward deployment.
+##### Backward deployment on iOS 12.1-
 
-For CocoaPods user, you can skip the platform version validation in Podfile with:
+For deployment target version below iOS 12.2 (The first version which Swift 5 Runtime bundled in iOS system), you have to change the min deployment target version of SDWebImageSwiftUI. This may take some side effect on compiler's optimization and trigger massive warnings for some frameworks.
+
+However, for iOS 12.2+, you can still keep the min deployment target version to iOS 13, no extra warnings or performance slow down for iOS 13 client.
+
+Because Swift use the min deployment target version to detect whether to link the App bundled Swift runtime, or the System built-in one (`/usr/lib/swift/libswiftCore.dylib`).
+
++ For CocoaPods user, you can change the min deployment target version in the Podfile via post installer:
+
+```ruby
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '11.0' # version you need
+    end
+  end
+end
+```
+
++ For Carthage user, you can use `carthage update --no-build` to download the dependency, then change the Xcode Project's deployment target version and build the binary framework.
+
++ For SwiftPM user, you have to use the local dependency (with the Git submodule) to change the deployment target version.
+
+##### Backward deployment on iOS 12.2+
+
++ For Carthage user, the built binary framework will use [Library Evolution](https://swift.org/blog/abi-stability-and-more/) to support for backward deployment.
+
++ For CocoaPods user, you can skip the platform version validation in Podfile with:
 
 ```ruby
 platform :ios, '13.0' # This does not effect your App Target's deployment target version, just a hint for CocoaPods
 ```
+
++ For SwiftPM user, SwiftPM does not support weak linking nor Library Evolution, so it can not deployment to iOS 12+ user without changing the min deployment target.
     
-+ Add **all the SwiftUI code** with the available annotation and runtime check, like this:
+##### Add available annotation
+
+Add **all the SwiftUI code** with the available annotation and runtime check, like this:
 
 ```swift
 // AppDelegate.swift

--- a/SDWebImageSwiftUI.podspec
+++ b/SDWebImageSwiftUI.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SDWebImageSwiftUI'
-  s.version          = '1.0.0-beta3'
+  s.version          = '1.0.0'
   s.summary          = 'SwiftUI Image loading and Animation framework powered by SDWebImage'
 
   s.description      = <<-DESC

--- a/SDWebImageSwiftUI.xcodeproj/project.pbxproj
+++ b/SDWebImageSwiftUI.xcodeproj/project.pbxproj
@@ -820,6 +820,7 @@
 		3211F84C23DE984D00FC757F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -841,6 +842,7 @@
 		3211F84D23DE984D00FC757F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -862,6 +864,7 @@
 		321C1D4423DEC17D009CF62A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -884,6 +887,7 @@
 		321C1D4523DEC17D009CF62A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -906,6 +910,7 @@
 		321C1D5323DEC185009CF62A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -928,6 +933,7 @@
 		321C1D5423DEC185009CF62A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_STYLE = Automatic;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -13,7 +13,7 @@ import SDWebImage
 class ImageManager : ObservableObject {
     @Published var image: PlatformImage? // loaded image, note when progressive loading, this will published multiple times with different partial image
     @Published var isLoading: Bool = false // whether network is loading or cache is querying, should only be used for indicator binding
-    @Published var progress: CGFloat = 0 // network progress, should only be used for indicator binding
+    @Published var progress: Double = 0 // network progress, should only be used for indicator binding
     
     var manager: SDWebImageManager
     weak var currentOperation: SDWebImageOperation? = nil
@@ -49,9 +49,9 @@ class ImageManager : ObservableObject {
             guard let self = self else {
                 return
             }
-            let progress: CGFloat
+            let progress: Double
             if (expectedSize > 0) {
-                progress = CGFloat(receivedSize) / CGFloat(expectedSize)
+                progress = Double(receivedSize) / Double(expectedSize)
             } else {
                 progress = 0
             }

--- a/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
@@ -12,14 +12,14 @@ import SwiftUI
 /// A  type to build the indicator
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct Indicator<T> where T : View {
-    var content: (Binding<Bool>, Binding<CGFloat>) -> T
+    var content: (Binding<Bool>, Binding<Double>) -> T
     
     /// Create a indicator with builder
     /// - Parameter builder: A builder to build indicator
     /// - Parameter isAnimating: A Binding to control the animation. If image is during loading, the value is true, else (like start loading) the value is false.
-    /// - Parameter progress: A Binding to control the progress during loading. If no progress can be reported, the value is 0.
+    /// - Parameter progress: A Binding to control the progress during loading. Value between [0, 1]. If no progress can be reported, the value is 0.
     /// Associate a indicator when loading image with url
-    public init(@ViewBuilder content: @escaping (_ isAnimating: Binding<Bool>, _ progress: Binding<CGFloat>) -> T) {
+    public init(@ViewBuilder content: @escaping (_ isAnimating: Binding<Bool>, _ progress: Binding<Double>) -> T) {
         self.content = content
     }
 }

--- a/SDWebImageSwiftUI/Classes/Indicator/ProgressIndicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/ProgressIndicator.swift
@@ -13,7 +13,7 @@ import SwiftUI
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct ProgressIndicator: PlatformViewRepresentable {
     @Binding var isAnimating: Bool
-    @Binding var progress: CGFloat
+    @Binding var progress: Double
     var style: Style
     
     /// Create indicator with animation binding, progress binding and the style
@@ -21,7 +21,7 @@ public struct ProgressIndicator: PlatformViewRepresentable {
     ///   - isAnimating: The binding to control the animation
     ///   - progress: The binding to update the progress
     ///   - style: The indicator style
-    public init(_ isAnimating: Binding<Bool>, progress: Binding<CGFloat>, style: Style = .default) {
+    public init(_ isAnimating: Binding<Bool>, progress: Binding<Double>, style: Style = .default) {
         self._isAnimating = isAnimating
         self._progress = progress
         self.style = style

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -285,7 +285,7 @@ extension WebImage {
     
     /// Associate a indicator when loading image with url, convenient method with block
     /// - Parameter content: A view that describes the indicator.
-    public func indicator<T>(@ViewBuilder content: @escaping (_ isAnimating: Binding<Bool>, _ progress: Binding<CGFloat>) -> T) -> some View where T : View {
+    public func indicator<T>(@ViewBuilder content: @escaping (_ isAnimating: Binding<Bool>, _ progress: Binding<Double>) -> T) -> some View where T : View {
         return indicator(Indicator(content: content))
     }
 }

--- a/SDWebImageSwiftUI/Module/Info.plist
+++ b/SDWebImageSwiftUI/Module/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.0-beta3</string>
+	<string>1.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>

--- a/Tests/IndicatorTests.swift
+++ b/Tests/IndicatorTests.swift
@@ -55,7 +55,7 @@ class IndicatorTests: XCTestCase {
     func testProgressIndicator() throws {
         let expectation = self.expectation(description: "Progress indicator")
         let binding = Binding<Bool>(wrappedValue: true)
-        let progress = Binding<CGFloat>(wrappedValue: 0)
+        let progress = Binding<Double>(wrappedValue: 0)
         let indicator = ProgressIndicator(binding, progress: progress)
         ViewHosting.host(view: indicator)
         let indicatorView = try indicator.inspect().actualView().platformView().wrapped


### PR DESCRIPTION
This is the first major version. Which provide the following changes compared to 0.11.x version:

+ Animated Support on `WebImage`
+ Full Unit Testing
+ API stable

Breaking changes compared to previous beta version:

+ Indicator's `progress` type now changed from `CGFloat` to `Double`