### PR TITLE
Animatedimage little patch - UIKit/AppKit animated image now applied for resizingMode

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -556,11 +556,11 @@ extension AnimatedImage {
         // So, if we don't override this method, SwiftUI ignore the content mode on actual ImageView
         // To workaround, we want to call the default `SwifUI.View.aspectRatio(_:contentMode:)` method
         // But 2: there are no way to call a Protocol Extention default implementation in Swift 5.1
-        // So, we need a hack, that create a empty modifier, they call method on that view instead
+        // So, we directly call the implementation detail modifier instead
         // Fired Radar: FB7413534
         self.imageLayout.aspectRatio = aspectRatio
         self.imageLayout.contentMode = contentMode
-        return self.modifier(EmptyModifier()).aspectRatio(aspectRatio, contentMode: contentMode)
+        return self.modifier(_AspectRatioLayout(aspectRatio: aspectRatio, contentMode: contentMode))
     }
 
     /// Constrains this view's dimensions to the aspect ratio of the given size.
@@ -572,13 +572,7 @@ extension AnimatedImage {
     /// - Returns: A view that constrains this view's dimensions to
     ///   `aspectRatio`, using `contentMode` as its scaling algorithm.
     public func aspectRatio(_ aspectRatio: CGSize, contentMode: ContentMode) -> some View {
-        var ratio: CGFloat?
-        if aspectRatio.width > 0 && aspectRatio.height > 0 {
-            ratio = aspectRatio.width / aspectRatio.height
-        } else {
-            NSException(name: .invalidArgumentException, reason: "\(type(of: self)).\(#function) should be called with positive aspectRatio", userInfo: nil).raise()
-        }
-        return self.aspectRatio(ratio, contentMode: contentMode)
+        return self.aspectRatio(aspectRatio.width / aspectRatio.height, contentMode: contentMode)
     }
 
     /// Scales this view to fit its parent.

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -350,7 +350,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
         
         // Animated Image does not support resizing mode and rendering mode
-        if let image = view.wrapped.image, !image.sd_isAnimated, !image.conforms(to: SDAnimatedImageProtocol.self) {
+        if let image = view.wrapped.image, !image.conforms(to: SDAnimatedImageProtocol.self) {
             var image = image
             // ResizingMode
             if let resizingMode = imageLayout.resizingMode, imageLayout.capInsets != EdgeInsets() {


### PR DESCRIPTION
Changes:

+ `aspectRatio(_:contentMode)` method now use the SwiftUI implementation with internel modifier, instead of empty modifier. The empty modifier will cause extra attribute graph during debugging, so this can match SwiftUI.Image behavior.
+ `UIAnimatedImage` or `NSImage` with GIF, can now supports changing rendering mode, which let you use it with tintColor. And also the resizingMode. Previouslly this limit applied for both SDAnimatedImage or UIKit/AppKit animated image