### PR TITLE
Fix the issue when dealloc AnimatedImage's native View, the window does not exist and cause internel Crash

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -218,11 +218,13 @@ public struct AnimatedImage : PlatformViewRepresentable {
             // This is a hack because of Xcode 11.3 bug, the @Published does not trigger another `updateUIView` call
             // Here I have to use UIKit/AppKit API to triger the same effect (the window change implicitly cause re-render)
             if let hostingView = AnimatedImage.findHostingView(from: view) {
-                #if os(macOS)
-                hostingView.viewDidMoveToWindow()
-                #else
-                hostingView.didMoveToWindow()
-                #endif
+                if let _ = hostingView.window {
+                    #if os(macOS)
+                    hostingView.viewDidMoveToWindow()
+                    #else
+                    hostingView.didMoveToWindow()
+                    #endif
+                }
             }
             self.imageLoading.image = image
             self.imageLoading.isLoading = false


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6919743/77845856-8e2cbc00-71e4-11ea-9692-5c22d7b81cc6.png)
