### PR TITLE
Fix the issue when using WebImage with some transition like scaleEffect, each time the new state update will cause unused image fetching

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/DetailView.swift
+++ b/Example/SDWebImageSwiftUIDemo/DetailView.swift
@@ -38,7 +38,7 @@ struct DetailView: View {
     let url: String
     let animated: Bool
     @State var isAnimating: Bool = true
-    @State var lastScaleValue: CGFloat = 1.0
+    @State var lastScale: CGFloat = 1.0
     @State var scale: CGFloat = 1.0
     @Environment(\.presentationMode) var presentationMode
     @EnvironmentObject var settings: UserSettings
@@ -75,12 +75,12 @@ struct DetailView: View {
         return contentView()
             .scaleEffect(self.scale)
             .gesture(MagnificationGesture(minimumScaleDelta: 0.1).onChanged { value in
-                let delta = value / self.lastScaleValue
-                self.lastScaleValue = value
+                let delta = value / self.lastScale
+                self.lastScale = value
                 let newScale = self.scale * delta
                 self.scale = min(max(newScale, 0.5), 2)
             }.onEnded { value in
-                self.lastScaleValue = 1.0
+                self.lastScale = 1.0
             })
         #endif
         #if os(tvOS)

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -109,6 +109,7 @@ public final class ImageManager : ObservableObject {
     /// Prefetch the initial state of image, currently query the memory cache only
     func prefetch() {
         // Use the options processor if provided
+        let options = self.options
         var context = self.context
         if let result = manager.optionsProcessor?.processedResult(for: url, options: options, context: context) {
             context = result.context
@@ -118,7 +119,7 @@ public final class ImageManager : ObservableObject {
         // This callback is synchronzied
         manager.imageCache.containsImage(forKey: key, cacheType: .memory) { [unowned self] (cacheType) in
             if cacheType == .memory {
-                self.manager.imageCache.queryImage(forKey: key, options: self.options, context: self.context) { [unowned self] (image, data, cacheType) in
+                self.manager.imageCache.queryImage(forKey: key, options: options, context: context) { [unowned self] (image, data, cacheType) in
                     self.image = image
                 }
             }

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -27,6 +27,7 @@ public final class ImageManager : ObservableObject {
     var manager: SDWebImageManager
     weak var currentOperation: SDWebImageOperation? = nil
     var isFirstLoad: Bool = true // false after first call `load()`
+    var isFirstPrefetch: Bool = true // false after first call `prefetch()`
     
     var url: URL?
     var options: SDWebImageOptions
@@ -108,6 +109,7 @@ public final class ImageManager : ObservableObject {
     
     /// Prefetch the initial state of image, currently query the memory cache only
     func prefetch() {
+        isFirstPrefetch = false
         // Use the options processor if provided
         let options = self.options
         var context = self.context
@@ -121,6 +123,9 @@ public final class ImageManager : ObservableObject {
             if cacheType == .memory {
                 self.manager.imageCache.queryImage(forKey: key, options: options, context: context) { [unowned self] (image, data, cacheType) in
                     self.image = image
+                    if let image = image {
+                        self.successBlock?(image, cacheType)
+                    }
                 }
             }
         }

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -106,18 +106,20 @@ public final class ImageManager : ObservableObject {
         }
     }
     
-    /// Prefetch the initial state of image
-    internal func prefetch() {
-        let key = manager.cacheKey(for: url)
-        if let imageCache = manager.imageCache as? SDImageCache {
-            self.image = imageCache.imageFromMemoryCache(forKey: key)
-        } else {
-            // generic API
-            manager.imageCache.containsImage(forKey: key, cacheType: .memory) { [unowned self] (cacheType) in
-                if cacheType == .memory {
-                    self.manager.imageCache.queryImage(forKey: key, options: self.options, context: self.context) { [unowned self] (image, data, cacheType) in
-                        self.image = image
-                    }
+    /// Prefetch the initial state of image, currently query the memory cache only
+    func prefetch() {
+        // Use the options processor if provided
+        var context = self.context
+        if let result = manager.optionsProcessor?.processedResult(for: url, options: options, context: context) {
+            context = result.context
+        }
+        // TODO: before SDWebImage 5.7.0, this is the SPI. Remove later
+        let key = manager.perform(Selector(("cacheKeyForURL:context:")), with: url, with: context)?.takeUnretainedValue() as? String
+        // This callback is synchronzied
+        manager.imageCache.containsImage(forKey: key, cacheType: .memory) { [unowned self] (cacheType) in
+            if cacheType == .memory {
+                self.manager.imageCache.queryImage(forKey: key, options: self.options, context: self.context) { [unowned self] (image, data, cacheType) in
+                    self.image = image
                 }
             }
         }

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -106,6 +106,23 @@ public final class ImageManager : ObservableObject {
         }
     }
     
+    /// Prefetch the initial state of image
+    internal func prefetch() {
+        let key = manager.cacheKey(for: url)
+        if let imageCache = manager.imageCache as? SDImageCache {
+            self.image = imageCache.imageFromMemoryCache(forKey: key)
+        } else {
+            // generic API
+            manager.imageCache.containsImage(forKey: key, cacheType: .memory) { [unowned self] (cacheType) in
+                if cacheType == .memory {
+                    self.manager.imageCache.queryImage(forKey: key, options: self.options, context: self.context) { [unowned self] (image, data, cacheType) in
+                        self.image = image
+                    }
+                }
+            }
+        }
+    }
+    
 }
 
 // Completion Handler

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -57,13 +57,15 @@ public struct WebImage : View {
             }
         }
         self.imageManager = ImageManager(url: url, options: options, context: context)
-        // this prefetch the memory cache of image, to immediately render it on screen
-        // this solve the case when `onAppear` not been called, for example, some transaction indeterminate state, SwiftUI :)
-        self.imageManager.prefetch()
     }
     
     public var body: some View {
-        Group {
+        // this prefetch the memory cache of image, to immediately render it on screen
+        // this solve the case when `onAppear` not been called, for example, some transaction indeterminate state, SwiftUI :)
+        if imageManager.isFirstPrefetch {
+            self.imageManager.prefetch()
+        }
+        return Group {
             if imageManager.image != nil {
                 if isAnimating && !self.imageManager.isIncremental {
                     if currentFrame != nil {

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -58,7 +58,7 @@ public struct WebImage : View {
         }
         self.imageManager = ImageManager(url: url, options: options, context: context)
         // this prefetch the memory cache of image, to immediately render it on screen
-        // this solve the cause when `onAppear` not been called, for example, some transaction indetermite state :)
+        // this solve the case when `onAppear` not been called, for example, some transaction indeterminate state, SwiftUI :)
         self.imageManager.prefetch()
     }
     


### PR DESCRIPTION
See our demo:

```swift
WebImage(url: url, options:[.delayPlaceholder])
    .placeholder(.wifiExclamationmark)
    .scaleEffect(self.scale)
    .gesture(MagnificationGesture(minimumScaleDelta: 0.1).onChanged { value in
        let delta = value / self.lastScale
        self.lastScale = value
        let newScale = self.scale * delta
        self.scale = min(max(newScale, 0.5), 2)
    }.onEnded { value in
        self.lastScale = 1.0
    })
```

Before this fix, when network load failed, each time you zoom your finder, the new SDWebImage loadImage function call will trigger, this cause huge performance cost, worstly, the UI part will show a placeholder with flashback.

To workaround with this, we roll back to load the image in `WebImage's first Appear`. However, we have to solve the issue #20 #19 

So, this time, we use a trick (smart ?) solution: We query the memory cache firstlly during WebImage init method. This is fast because it just a NSCache objectForKey call.

If memory cache hit, the image does not show placeholder or empty, so fix the `editMode` issue.