### PR TITLE
Feature AnimatedImage placeholder view builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,11 @@ var body: some View {
         AnimatedImage(name: "animation1", isAnimating: $isAnimating)) // Animation control binding
         .maxBufferSize(.max)
         .onViewUpdate { view, context in // Advanced native view coordinate
+            // AppKit tooltip for mouse hover
             view.toolTip = "Mouseover Tip"
+            // UIKit advanced content mode
+            view.contentMode = .topLeft
+            // Coordinator, used for Cocoa Binding or Delegate method
             let coordinator = context.coordinator
         }
     }
@@ -190,6 +194,8 @@ var body: some View {
 Note: `AnimatedImage` supports both image url or image data for animated image format. Which use the SDWebImage's [Animated ImageView](https://github.com/SDWebImage/SDWebImage/wiki/Advanced-Usage#animated-image-50) for internal implementation. Pay attention that since this base on UIKit/AppKit representable, some advanced SwiftUI layout and animation system may not work as expected. You may need UIKit/AppKit and Core Animation to modify the native view.
 
 Note: `AnimatedImage` some methods like `.transition`, `.indicator` and `.aspectRatio` have the same naming as `SwiftUI.View` protocol methods. But the args receive the different type. This is because `AnimatedImage` supports to be used with UIKit/AppKit component and animation. If you find ambiguity, use full type declaration instead of the dot expression syntax.
+
+Note: some of methods on `AnimatedImage` will return `some View`, a new Modified Content. You'll lose the type related modifier method. For this case, you can either reorder the method call, or use Native View in `.onViewUpdate` for rescue.
 
 ```swift
 var body: some View {

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ var body: some View {
         }
         .resizable() // Resizable like SwiftUI.Image, you must use this modifier or the view will use the image bitmap size
         .placeholder(UIImage(systemName: "photo")) // Placeholder Image
+        // Supports ViewBuilder as well
+        .placeholder {
+            Circle().foregroundColor(.gray)
+        }
         .indicator(SDWebImageActivityIndicator.medium) // Activity Indicator
         .transition(.fade) // Fade Transition
         .scaledToFit() // Attention to call it on AnimatedImage, but not `some View` after View Modifier (Swift Protocol Extension method is static dispatched)

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -123,6 +123,9 @@ public final class ImageManager : ObservableObject {
         manager.loadImage(with: url, options: options, context: context, progress: nil) { (image, data, error, cacheType, finished, imageUrl) in
             // This will callback immediately
             self.image = image
+            if let image = image {
+                self.successBlock?(image, cacheType)
+            }
         }
     }
     

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -122,5 +122,21 @@ public class ProgressIndicatorWrapper : PlatformView {
         addSubview(wrapped)
     }
 }
+extension PlatformView {
+    /// Adds constraints to this `UIView` instances `superview` object to make sure this always has the same size as the superview.
+    /// Please note that this has no effect if its `superview` is `nil` – add this `UIView` instance as a subview before calling this.
+    func bindFrameToSuperviewBounds() {
+        guard let superview = self.superview else {
+            print("Error! `superview` was nil – call `addSubview(view: UIView)` before calling `bindFrameToSuperviewBounds()` to fix this.")
+            return
+        }
+
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.topAnchor.constraint(equalTo: superview.topAnchor, constant: 0).isActive = true
+        self.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: 0).isActive = true
+        self.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 0).isActive = true
+        self.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: 0).isActive = true
+    }
+}
 
 #endif

--- a/Tests/AnimatedImageTests.swift
+++ b/Tests/AnimatedImageTests.swift
@@ -163,6 +163,9 @@ class AnimatedImageTests: XCTestCase {
             XCTAssertEqual(context.coordinator.userInfo?["foo"] as? String, "bar")
         }
         .placeholder(PlatformImage())
+        .placeholder {
+            Circle()
+        }
         .indicator(SDWebImageActivityIndicator.medium)
         // Image
         .resizable()

--- a/Tests/WebImageTests.swift
+++ b/Tests/WebImageTests.swift
@@ -82,6 +82,7 @@ class WebImageTests: XCTestCase {
         .onProgress { _, _ in
             
         }
+        .placeholder(.init(platformImage: PlatformImage()))
         .placeholder {
             Circle()
         }


### PR DESCRIPTION
This PR supports the `@ViewBuilder` API to create placeholder on `AnimatedImage`.

The channlege is that `AnimatedImage` use `UIViewRepresentable`, which the `body` func is override by SwiftUI internel logic. So we can not use the same design as `WebImage` (which return different Image based on loading status)

So, instead, we use the HostingView, to inject the View Hierarchy. The placeholder is above the original SDAnimatedImageView, and controls its `isHidden` property during loading.

Note the placeholder and indicator can be used at the same time, we need to considerate this case and adjust the View Hierarchy level