### PR TITLE
Revert the changes to prefetch the image url from memory cache

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -27,7 +27,6 @@ public final class ImageManager : ObservableObject {
     var manager: SDWebImageManager
     weak var currentOperation: SDWebImageOperation? = nil
     var isFirstLoad: Bool = true // false after first call `load()`
-    var isFirstPrefetch: Bool = true // false after first call `prefetch()`
     
     var url: URL?
     var options: SDWebImageOptions
@@ -104,28 +103,6 @@ public final class ImageManager : ObservableObject {
             operation.cancel()
             currentOperation = nil
             isLoading = false
-        }
-    }
-    
-    /// Prefetch the initial state of image, currently query the memory cache only
-    func prefetch() {
-        isFirstPrefetch = false
-        var options = self.options
-        if options.contains(.fromLoaderOnly) {
-            // If user indeed ignore cache, don't do prefetch
-            return
-        }
-        // Use `.fromCacheOnly` to query cache only
-        options.insert(.fromCacheOnly)
-        var context = self.context ?? [:]
-        context[.queryCacheType] = SDImageCacheType.memory.rawValue
-        // Use `.queryCacheType` to query memory cache only
-        manager.loadImage(with: url, options: options, context: context, progress: nil) { (image, data, error, cacheType, finished, imageUrl) in
-            // This will callback immediately
-            self.image = image
-            if let image = image {
-                self.successBlock?(image, cacheType)
-            }
         }
     }
     

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -60,10 +60,9 @@ public struct WebImage : View {
     }
     
     public var body: some View {
-        // this prefetch the memory cache of image, to immediately render it on screen
-        // this solve the case when `onAppear` not been called, for example, some transaction indeterminate state, SwiftUI :)
-        if imageManager.isFirstPrefetch {
-            imageManager.prefetch()
+        // This solve the case when WebImage created with new URL, but `onAppear` not been called, for example, some transaction indeterminate state, SwiftUI :)
+        if imageManager.isFirstLoad {
+            imageManager.load()
         }
         return Group {
             if imageManager.image != nil {
@@ -100,7 +99,7 @@ public struct WebImage : View {
                 setupPlaceholder()
                 .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                 .onAppear {
-                    // load remote image when first appear
+                    // Load remote image when first appear
                     if self.imageManager.isFirstLoad {
                         self.imageManager.load()
                         return


### PR DESCRIPTION
because there are cases that the `onAppear` does not get called at all, which need at least update the remote URL. See #105 #103 

We should provide the correctness, more than performance, even we queried multiple times than we should, SDWebImage itself will take care of extra query.