### PR TITLE
Add the support for image data observable on ImageManager

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -15,6 +15,8 @@ import SDWebImage
 public final class ImageManager : ObservableObject {
     /// loaded image, note when progressive loading, this will published multiple times with different partial image
     @Published public var image: PlatformImage?
+    /// loaded image data, may be nil if hit from memory cache. This will only published once even on incremental image loading
+    @Published public var imageData: Data?
     /// loading error, you can grab the error code and reason listed in `SDWebImageErrorDomain`, to provide a user interface about the error reason
     @Published public var error: Error?
     /// whether network is loading or cache is querying, should only be used for indicator binding
@@ -87,6 +89,7 @@ public final class ImageManager : ObservableObject {
             self.error = error
             self.isIncremental = !finished
             if finished {
+                self.imageData = data
                 self.isLoading = false
                 self.progress = 1
                 if let image = image {


### PR DESCRIPTION
Add the support to observe the image data loaded success. This is used for user who want to have some extra setup logic for image data (not image bitmap object (UIImage).

However, due to the API semversion, we can not break current `onSuccess` API, which only receive the `(UIImage, SDImageCacheType)`. Which will be changed in v2.0.0

So I just only add the `imageData` published property on manager.

See #104 