### PR TITLE
Add the same overload method for onSuccess API, which introduce the image data arg. Keep the source code compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,9 @@ github "SDWebImage/SDWebImageSwiftUI"
 var body: some View {
     WebImage(url: URL(string: "https://nokiatech.github.io/heif/content/images/ski_jump_1440x960.heic"))
     // Supports options and context, like `.delayPlaceholder` to show placeholder only when error
-    .onSuccess { image, cacheType in
+    .onSuccess { image, data, cacheType in
         // Success
+        // Note: Data exist only when queried from disk cache or network. Use `.queryMemoryData` if you really need data
     }
     .resizable() // Resizable like SwiftUI.Image, you must use this modifier or the view will use the image bitmap size
     .placeholder(Image(systemName: "photo")) // Placeholder Image

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -266,9 +266,32 @@ extension WebImage {
     
     /// Provide the action when image load successes.
     /// - Parameters:
+    ///   - action: The action to perform. The first arg is the loaded image. If `action` is `nil`, the call has no effect.
+    /// - Returns: A view that triggers `action` when this image load successes.
+    public func onSuccess(perform action: @escaping (PlatformImage) -> Void) -> WebImage {
+        let action = action
+        self.imageManager.successBlock = { image, _, _ in
+            action(image)
+        }
+        return self
+    }
+    
+    /// Provide the action when image load successes.
+    /// - Parameters:
     ///   - action: The action to perform. The first arg is the loaded image, the second arg is the cache type loaded from. If `action` is `nil`, the call has no effect.
     /// - Returns: A view that triggers `action` when this image load successes.
-    public func onSuccess(perform action: ((PlatformImage, SDImageCacheType) -> Void)? = nil) -> WebImage {
+    public func onSuccess(perform action: @escaping (PlatformImage, SDImageCacheType) -> Void) -> WebImage {
+        self.imageManager.successBlock = { image, _, cacheType in
+            action(image, cacheType)
+        }
+        return self
+    }
+    
+    /// Provide the action when image load successes.
+    /// - Parameters:
+    ///   - action: The action to perform. The first arg is the loaded image, the second arg is the loaded image data, the third arg is the cache type loaded from. If `action` is `nil`, the call has no effect.
+    /// - Returns: A view that triggers `action` when this image load successes.
+    public func onSuccess(perform action: ((PlatformImage, Data?, SDImageCacheType) -> Void)? = nil) -> WebImage {
         self.imageManager.successBlock = action
         return self
     }

--- a/Tests/AnimatedImageTests.swift
+++ b/Tests/AnimatedImageTests.swift
@@ -74,7 +74,8 @@ class AnimatedImageTests: XCTestCase {
         let expectation = self.expectation(description: "AnimatedImage url initializer")
         let imageUrl = URL(string: "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif")
         let imageView = AnimatedImage(url: imageUrl)
-        .onSuccess { image, cacheType in
+        .onSuccess { image, data, cacheType in
+            XCTAssertNotNil(image)
             if let animatedImage = image as? SDAnimatedImage {
                 XCTAssertEqual(animatedImage.animatedImageLoopCount, 0)
                 XCTAssertEqual(animatedImage.animatedImageFrameCount, 389)
@@ -88,7 +89,7 @@ class AnimatedImageTests: XCTestCase {
         ViewHosting.host(view: imageView)
         let animatedImageView = try imageView.inspect().actualView().platformView().wrapped
         XCTAssertEqual(animatedImageView.sd_imageURL, imageUrl)
-        self.waitForExpectations(timeout: 5, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
         ViewHosting.expel()
     }
     


### PR DESCRIPTION
This solve the #104.

By using the overload method, this can keep source code compatibility, so this is marked as 1.x not 2.x.