### PR TITLE
Feature convenient transition with duration

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -173,8 +173,7 @@ struct ContentView: View {
                             WebImage(url: URL(string:url), isAnimating: self.$animated)
                             .resizable()
                             .indicator(.activity)
-                            .animation(.easeInOut(duration: 0.5))
-                            .transition(.fade)
+                            .transition(.fade(duration: 0.5))
                             .scaledToFit()
                             .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
                             #endif
@@ -187,8 +186,7 @@ struct ContentView: View {
                              }
                              */
                             .indicator(.activity)
-                            .animation(.easeInOut(duration: 0.5))
-                            .transition(.fade)
+                            .transition(.fade(duration: 0.5))
                             .scaledToFit()
                             .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
                         }

--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ var body: some View {
         Rectangle().foregroundColor(.gray)
     }
     .indicator(.activity) // Activity Indicator
-    .animation(.easeInOut(duration: 0.5)) // Animation Duration
-    .transition(.fade) // Fade Transition
+    .transition(.fade(duration: 0.5)) // Fade Transition with duration
     .scaledToFit()
     .frame(width: 300, height: 300, alignment: .center)
 }

--- a/SDWebImageSwiftUI/Classes/Transition/Transition.swift
+++ b/SDWebImageSwiftUI/Classes/Transition/Transition.swift
@@ -18,9 +18,27 @@ extension AnyTransition {
         return AnyTransition.asymmetric(insertion: insertion, removal: removal)
     }
     
+    /// Fade-in transition with duration
+    /// - Parameter duration: transition duration, use ease-in-out
+    /// - Returns: A transition with duration
+    public static func fade(duration: Double) -> AnyTransition {
+        let insertion = AnyTransition.opacity.animation(.easeInOut(duration: duration))
+        let removal = AnyTransition.identity
+        return AnyTransition.asymmetric(insertion: insertion, removal: removal)
+    }
+    
     /// Flip from left transition
     public static var flipFromLeft: AnyTransition {
         let insertion = AnyTransition.move(edge: .leading)
+        let removal = AnyTransition.identity
+        return AnyTransition.asymmetric(insertion: insertion, removal: removal)
+    }
+    
+    /// Flip from left transition with duration
+    /// - Parameter duration: transition duration, use ease-in-out
+    /// - Returns: A transition with duration
+    public static func flipFromLeft(duration: Double) -> AnyTransition {
+        let insertion = AnyTransition.move(edge: .leading).animation(.easeInOut(duration: duration))
         let removal = AnyTransition.identity
         return AnyTransition.asymmetric(insertion: insertion, removal: removal)
     }
@@ -32,6 +50,15 @@ extension AnyTransition {
         return AnyTransition.asymmetric(insertion: insertion, removal: removal)
     }
     
+    /// Flip from right transition with duration
+    /// - Parameter duration: transition duration, use ease-in-out
+    /// - Returns: A transition with duration
+    public static func flipFromRight(duration: Double) -> AnyTransition {
+        let insertion = AnyTransition.move(edge: .trailing).animation(.easeInOut(duration: duration))
+        let removal = AnyTransition.identity
+        return AnyTransition.asymmetric(insertion: insertion, removal: removal)
+    }
+    
     /// Flip from top transition
     public static var flipFromTop: AnyTransition {
         let insertion = AnyTransition.move(edge: .top)
@@ -39,9 +66,27 @@ extension AnyTransition {
         return AnyTransition.asymmetric(insertion: insertion, removal: removal)
     }
     
+    /// Flip from top transition with duration
+    /// - Parameter duration: transition duration, use ease-in-out
+    /// - Returns: A transition with duration
+    public static func flipFromTop(duration: Double) -> AnyTransition {
+        let insertion = AnyTransition.move(edge: .top).animation(.easeInOut(duration: duration))
+        let removal = AnyTransition.identity
+        return AnyTransition.asymmetric(insertion: insertion, removal: removal)
+    }
+    
     /// Flip from bottom transition
     public static var flipFromBottom: AnyTransition {
         let insertion = AnyTransition.move(edge: .bottom)
+        let removal = AnyTransition.identity
+        return AnyTransition.asymmetric(insertion: insertion, removal: removal)
+    }
+    
+    /// Flip from bottom transition with duration
+    /// - Parameter duration: transition duration, use ease-in-out
+    /// - Returns: A transition with duration
+    public static func flipFromBottom(duration: Double) -> AnyTransition {
+        let insertion = AnyTransition.move(edge: .bottom).animation(.easeInOut(duration: duration))
         let removal = AnyTransition.identity
         return AnyTransition.asymmetric(insertion: insertion, removal: removal)
     }


### PR DESCRIPTION
This is a workaround for #115 

Note: The `.fade` API seems no longer working after iOS 13.2, but history works on iOS 13.0.

I have no good way to make it works. So I introduce the new convenient API for rescue. Use `.fade(duration: 0.5)` instead.