### PR TITLE
Update availability for all extensions for consistency 

### DIFF
--- a/SDWebImageSwiftUI/Classes/Image.swift
+++ b/SDWebImageSwiftUI/Classes/Image.swift
@@ -52,6 +52,7 @@ extension PlatformImage.Orientation {
     }
 }
 
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 extension Image.Orientation {
     @inlinable var toPlatform: PlatformImage.Orientation {
         switch self {

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -115,6 +115,7 @@ public final class ImageManager : ObservableObject {
 }
 
 // Completion Handler
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 extension ImageManager {
     /// Provide the action when image load fails.
     /// - Parameters:
@@ -157,4 +158,5 @@ extension ImageManager {
 }
 
 // Indicator Reportor
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 extension ImageManager: IndicatorReportable {}

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -122,6 +122,8 @@ public class ProgressIndicatorWrapper : PlatformView {
         addSubview(wrapped)
     }
 }
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 extension PlatformView {
     /// Adds constraints to this `UIView` instances `superview` object to make sure this always has the same size as the superview.
     /// Please note that this has no effect if its `superview` is `nil` – add this `UIView` instance as a subview before calling this.


### PR DESCRIPTION
Several extensions were missing the `@available` attributes.