### PR TITLE
Update the Example to make WebImage animatable by default

### DIFF
--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -155,7 +155,7 @@ struct ContentView: View {
                     HStack {
                         if self.animated {
                             #if os(macOS) || os(iOS) || os(tvOS)
-                            AnimatedImage(url: URL(string:url))
+                            AnimatedImage(url: URL(string:url), isAnimating: .constant(true))
                             .onViewUpdate { view, context in
                             #if os(macOS)
                                 view.toolTip = url
@@ -178,7 +178,7 @@ struct ContentView: View {
                             .frame(width: CGFloat(100), height: CGFloat(100), alignment: .center)
                             #endif
                         } else {
-                            WebImage(url: URL(string:url))
+                            WebImage(url: URL(string:url), isAnimating: .constant(true))
                             .resizable()
                             /**
                              .placeholder {

--- a/Example/SDWebImageSwiftUIDemo/DetailView.swift
+++ b/Example/SDWebImageSwiftUIDemo/DetailView.swift
@@ -36,7 +36,7 @@ extension Image {
 
 struct DetailView: View {
     let url: String
-    let animated: Bool
+    @State var animated: Bool = true // You can change between WebImage/AnimatedImage
     @State var isAnimating: Bool = true
     @State var lastScale: CGFloat = 1.0
     @State var scale: CGFloat = 1.0
@@ -45,25 +45,17 @@ struct DetailView: View {
     var body: some View {
         VStack {
             #if os(iOS) || os(tvOS)
-            if animated {
-                zoomView()
-                .navigationBarItems(trailing: Button(isAnimating ? "Stop" : "Start") {
-                    self.isAnimating.toggle()
-                })
-            } else {
-                zoomView()
-            }
+            zoomView()
+            .navigationBarItems(trailing: Button(isAnimating ? "Stop" : "Start") {
+                self.isAnimating.toggle()
+            })
             #endif
             #if os(macOS) || os(watchOS)
-            if animated {
-                zoomView()
-                .contextMenu {
-                    Button(isAnimating ? "Stop" : "Start") {
-                        self.isAnimating.toggle()
-                    }
+            zoomView()
+            .contextMenu {
+                Button(isAnimating ? "Stop" : "Start") {
+                    self.isAnimating.toggle()
                 }
-            } else {
-                zoomView()
             }
             #endif
         }
@@ -116,7 +108,7 @@ struct DetailView: View {
                 .scaledToFit()
                 #endif
             } else {
-                WebImage(url: URL(string:url), options: [.progressiveLoad, .delayPlaceholder])
+                WebImage(url: URL(string:url), options: [.progressiveLoad, .delayPlaceholder], isAnimating: $isAnimating)
                 .resizable()
                 .placeholder(.wifiExclamationmark)
                 .indicator(.progress)


### PR DESCRIPTION
Some user didn't find the way how to make `WebImage` rendering GIF/APNG images. So the demo add that by default.