### PR TITLE
Try to fix the recusive updateView when using AnimatedImage inside `ScrollView/LazyVStack`.

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -66,31 +66,6 @@ public class AnimatedImageViewWrapper : PlatformView {
     }
 }
 
-
-/// Store the Animated Image loading state, to avoid re-query duinrg `updateView(_:)` until Source of Truth changes
-@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
-extension PlatformView {
-    static private var sd_imageNameKey: Void?
-    static private var sd_imageDataKey: Void?
-    
-    var sd_imageName: String? {
-        get {
-            objc_getAssociatedObject(self, &PlatformView.sd_imageNameKey) as? String
-        }
-        set {
-            objc_setAssociatedObject(self, &PlatformView.sd_imageNameKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
-    var sd_imageData: Data? {
-        get {
-            objc_getAssociatedObject(self, &PlatformView.sd_imageDataKey) as? Data
-        }
-        set {
-            objc_setAssociatedObject(self, &PlatformView.sd_imageDataKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        }
-    }
-}
-
 /// Use wrapper to solve the `UIProgressView`/`NSProgressIndicator` frame origin NaN crash (SwiftUI's bug)
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public class ProgressIndicatorWrapper : PlatformView {

--- a/Tests/AnimatedImageTests.swift
+++ b/Tests/AnimatedImageTests.swift
@@ -46,7 +46,6 @@ class AnimatedImageTests: XCTestCase {
         } else {
             XCTFail("SDAnimatedImageView.image invalid")
         }
-        XCTAssertEqual(animatedImageView.sd_imageName, imageName)
         expectation.fulfill()
         self.waitForExpectations(timeout: 5, handler: nil)
         ViewHosting.expel()
@@ -64,7 +63,6 @@ class AnimatedImageTests: XCTestCase {
         } else {
             XCTFail("SDAnimatedImageView.image invalid")
         }
-        XCTAssertEqual(animatedImageView.sd_imageData, imageData)
         expectation.fulfill()
         self.waitForExpectations(timeout: 5, handler: nil)
         ViewHosting.expel()


### PR DESCRIPTION
Because from iOS 14+, the @Published update will always trigger another `updateUIView`. No hack and workaround is needed.

This fix #161 #121 

See screenshot:

![image](https://user-images.githubusercontent.com/6919743/108681376-0bae9880-752a-11eb-99e2-d1b85544abe7.png)
