### PR TITLE
Bump the limit to Xcode 12, because we need new iOS 14+ APIs check

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "SDWebImage/SDWebImage" ~> 5.7
+github "SDWebImage/SDWebImage" ~> 5.10

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -17,7 +17,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.7.0")
+        .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.10.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ All issue reports, feature requests, contributions, and GitHub stars are welcome
 
 ## Requirements
 
-+ Xcode 11+
++ Xcode 12+
 + iOS 13+
 + macOS 10.15+
 + tvOS 13+

--- a/SDWebImageSwiftUI.podspec
+++ b/SDWebImageSwiftUI.podspec
@@ -34,6 +34,6 @@ It brings all your favorite features from SDWebImage, like async image loading, 
   }
 
   s.weak_frameworks = 'SwiftUI', 'Combine'
-  s.dependency 'SDWebImage', '~> 5.7'
-  s.swift_version = '5.1'
+  s.dependency 'SDWebImage', '~> 5.10'
+  s.swift_version = '5.2'
 end

--- a/SDWebImageSwiftUI/Module/Info.plist
+++ b/SDWebImageSwiftUI/Module/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.5.0</string>
+	<string>1.6.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
This follows the other SDWebImage downstream dependency.