### PR TITLE
Fix the rare cases that WebImage will lost animation when visibility changes.

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImagePlayer.swift
+++ b/SDWebImageSwiftUI/Classes/ImagePlayer.swift
@@ -82,12 +82,7 @@ public final class ImagePlayer : ObservableObject {
                 
                 self.player = imagePlayer
                 
-                // Setup poster frame
-                if let cgImage = animatedImage.cgImage {
-                    currentFrame = PlatformImage(cgImage: cgImage, scale: animatedImage.scale, orientation: .up)
-                } else {
-                    currentFrame = .empty
-                }
+                imagePlayer.startPlaying()
             }
         }
     }


### PR DESCRIPTION
Always setup player to play as defaults to avoid this.

Reproduce demo:

```swift
 @State var urlString = "https://media0.giphy.com/media/3oEjHBop7WaPmuPryg/giphy.gif?cid=c3b5a7e2fdfc7510a373e125e129e199de61e11c3907222f&rid=giphy.gif"
    var body: some View {
        print("update view", urlString)
        return VStack {
            WebImage(url: URL(string: urlString), isAnimating: .constant(true))
                .resizable()
                .placeholder {
                    Rectangle().foregroundColor(.lightGray)
                }
                .indicator(.activity)
                .transition(.fade(duration: 0.5))
                .aspectRatio(contentMode: .fit)
                .frame(width: 200, height: 200)
            Button("test") {
                if urlString == "https://media0.giphy.com/media/3oEjHBop7WaPmuPryg/giphy.gif?cid=c3b5a7e2fdfc7510a373e125e129e199de61e11c3907222f&rid=giphy.gif" {
                    urlString = "https://media4.giphy.com/media/fLskTldNGlI3fISnLA/giphy.gif?cid=c3b5a7e2v2ma8dlz57l2swklkes7xi656k671vuhr5bxnkke&rid=giphy.gif"
                } else {
                    urlString = "https://media0.giphy.com/media/3oEjHBop7WaPmuPryg/giphy.gif?cid=c3b5a7e2fdfc7510a373e125e129e199de61e11c3907222f&rid=giphy.gif"
                }
            }
        }
    }
```