### PR TITLE
Remove the WebImage placeholder maxWidth/maxHeight modifier, this maybreak some use case like `TabView`. If user want to use placeholder, limit themselves

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImagePlayer.swift
+++ b/SDWebImageSwiftUI/Classes/ImagePlayer.swift
@@ -37,6 +37,22 @@ public final class ImagePlayer : ObservableObject {
     /// Current playing frame image
     @Published public var currentFrame: PlatformImage?
     
+    /// Current playing frame index
+    @Published public var currentFrameIndex: UInt = 0
+    
+    /// Current playing loop count
+    @Published public var currentLoopCount: UInt = 0
+    
+    /// Whether current player is valid for playing. This will check the internal player exist or not
+    public var isValid: Bool {
+        player != nil
+    }
+    
+    /// Current playing status
+    public var isPlaying: Bool {
+        player?.isPlaying ?? false
+    }
+    
     /// Start the animation
     public func startPlaying() {
         player?.startPlaying()
@@ -52,38 +68,44 @@ public final class ImagePlayer : ObservableObject {
         player?.stopPlaying()
     }
     
+    /// Seek to frame and loop count
+    public func seekToFrame(at: UInt, loopCount: UInt) {
+        player?.seekToFrame(at: at, loopCount: loopCount)
+    }
+    
     /// Clear the frame buffer
     public func clearFrameBuffer() {
         player?.clearFrameBuffer()
     }
     
-    
     /// Setup the player using Animated Image
     /// - Parameter image: animated image
-    public func setupPlayer(image: PlatformImage?) {
-        if player != nil {
+    public func setupPlayer(animatedImage: SDAnimatedImageProvider) {
+        if isValid {
             return
         }
-        if let animatedImage = image as? SDAnimatedImageProvider & PlatformImage {
-            if let imagePlayer = SDAnimatedImagePlayer(provider: animatedImage) {
-                imagePlayer.animationFrameHandler = { [weak self] (_, frame) in
-                    self?.currentFrame = frame
-                }
-                // Setup configuration
-                if let maxBufferSize = maxBufferSize {
-                    imagePlayer.maxBufferSize = maxBufferSize
-                }
-                if let customLoopCount = customLoopCount {
-                    imagePlayer.totalLoopCount = customLoopCount
-                }
-                imagePlayer.runLoopMode = runLoopMode
-                imagePlayer.playbackRate = playbackRate
-                imagePlayer.playbackMode = playbackMode
-                
-                self.player = imagePlayer
-                
-                imagePlayer.startPlaying()
+        if let imagePlayer = SDAnimatedImagePlayer(provider: animatedImage) {
+            imagePlayer.animationFrameHandler = { [weak self] (index, frame) in
+                self?.currentFrameIndex = index
+                self?.currentFrame = frame
             }
+            imagePlayer.animationLoopHandler = { [weak self] (loopCount) in
+                self?.currentLoopCount = loopCount
+            }
+            // Setup configuration
+            if let maxBufferSize = maxBufferSize {
+                imagePlayer.maxBufferSize = maxBufferSize
+            }
+            if let customLoopCount = customLoopCount {
+                imagePlayer.totalLoopCount = customLoopCount
+            }
+            imagePlayer.runLoopMode = runLoopMode
+            imagePlayer.playbackRate = playbackRate
+            imagePlayer.playbackMode = playbackMode
+            
+            self.player = imagePlayer
+            
+            imagePlayer.startPlaying()
         }
     }
 }

--- a/SDWebImageSwiftUI/Classes/ImagePlayer.swift
+++ b/SDWebImageSwiftUI/Classes/ImagePlayer.swift
@@ -78,7 +78,8 @@ public final class ImagePlayer : ObservableObject {
         player?.clearFrameBuffer()
     }
     
-    /// Setup the player using Animated Image
+    /// Setup the player using Animated Image.
+    /// After setup, you can always check `isValid` status, or call `startPlaying` to play the animation.
     /// - Parameter image: animated image
     public func setupPlayer(animatedImage: SDAnimatedImageProvider) {
         if isValid {
@@ -104,8 +105,6 @@ public final class ImagePlayer : ObservableObject {
             imagePlayer.playbackMode = playbackMode
             
             self.player = imagePlayer
-            
-            imagePlayer.startPlaying()
         }
     }
 }

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -80,7 +80,9 @@ public struct WebImage : View {
                     } else {
                         configure(image: imageManager.image!)
                         .onReceive(imageManager.$image) { image in
-                            self.imagePlayer.setupPlayer(image: image)
+                            if let animatedImage = image as? SDAnimatedImageProvider {
+                                self.imagePlayer.setupPlayer(animatedImage: animatedImage)
+                            }
                         }
                     }
                 } else {
@@ -92,7 +94,6 @@ public struct WebImage : View {
                 }
             } else {
                 setupPlaceholder()
-                .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
                 .onPlatformAppear(appear: {
                     // Load remote image when first appear
                     if self.imageManager.isFirstLoad {


### PR DESCRIPTION
This close #133 

Use `.frame(maxWidth: .infinity)` will cause the `TabView` crash. Actually I think this is SwiftUI issue.

But anyway, we don't limit the placeholder frame, if you want, limit yourself using `.placeholder { MyView().frame(width: 100) }`