### PR TITLE
Try to refactor the ImageManager trigger published value, avoiding the View will refreshing when deallocing

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -79,20 +79,13 @@ public final class ImageManager : ObservableObject {
             guard let self = self else {
                 return
             }
-            if let error = error as? SDWebImageError, error.code == .cancelled {
-                // Ignore user cancelled
-                // There are race condition when quick scroll
-                // Indicator modifier disapper and trigger `WebImage.body`
-                // So previous View struct call `onDisappear` and cancel the currentOperation
-                return
-            }
-            self.image = image
-            self.error = error
             self.isIncremental = !finished
+            self.image = image
             if finished {
+                self.isLoading = false
+                self.error = error
                 self.imageData = data
                 self.cacheType = cacheType
-                self.isLoading = false
                 self.progress = 1
                 if let image = image {
                     self.successBlock?(image, data, cacheType)
@@ -108,7 +101,6 @@ public final class ImageManager : ObservableObject {
         if let operation = currentOperation {
             operation.cancel()
             currentOperation = nil
-            isLoading = false
         }
     }
     

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -173,8 +173,12 @@ public struct WebImage : View {
         // Don't use `Group` because it will trigger `.onAppear` and `.onDisappear` when condition view removed, treat placeholder as an entire component
         if let placeholder = placeholder {
             // If use `.delayPlaceholder`, the placeholder is applied after loading failed, hide during loading :)
-            if imageManager.options.contains(.delayPlaceholder) && imageManager.isLoading {
-                return AnyView(configure(image: .empty))
+            if imageManager.options.contains(.delayPlaceholder) {
+                if imageManager.error != nil {
+                    return placeholder
+                } else {
+                    return AnyView(configure(image: .empty))
+                }
             } else {
                 return placeholder
             }

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -174,7 +174,7 @@ public struct WebImage : View {
         if let placeholder = placeholder {
             // If use `.delayPlaceholder`, the placeholder is applied after loading failed, hide during loading :)
             if imageManager.options.contains(.delayPlaceholder) {
-                if imageManager.error != nil {
+                if !imageManager.isLoading && imageManager.error != nil {
                     return placeholder
                 } else {
                     return AnyView(configure(image: .empty))


### PR DESCRIPTION
This may solve #176 


The callstack trace shows that UIHostingView's `dealloc` method will trigger the View's `onDisappear` method. And it use the unownded but not weak for the internal storage. If we trigger another `body` refreshing call from the Publisher (in the #176 is because of the `ImageManager.isLoading` property), this will cause the crash because the internal storage already been destroyed.

Instead, I try to avoid setting `isLoading` inside `cancel`. Tthis property is previouslly used to supports the `delayPlaceholder` feature.

`delayPlaceholder` in SDWebImage means:
+ If the loading has never started, only show the indicator (if available) but not placeholder.
+ If first loading failed, show the placeholder and disappear the indicator (if available)

So, instead I use the `error` to check whether there are loading failure. This can keep this function as well.