### PR TITLE
Readme corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ var body: some View {
         .playbackRate(2.0) // Playback speed rate
         
         // Bundle (not Asset Catalog)
-        AnimatedImage(name: "animation1", isAnimating: $isAnimating)) // Animation control binding
+        AnimatedImage(name: "animation1", isAnimating: $isAnimating) // Animation control binding
         .maxBufferSize(.max)
         .onViewUpdate { view, context in // Advanced native view coordinate
             // AppKit tooltip for mouse hover

--- a/README.md
+++ b/README.md
@@ -229,11 +229,18 @@ Note: `AnimatedImage` some methods like `.transition`, `.indicator` and `.aspect
 Note: some of methods on `AnimatedImage` will return `some View`, a new Modified Content. You'll lose the type related modifier method. For this case, you can either reorder the method call, or use Native View in `.onViewUpdate` for rescue.
 
 ```swift
+
+// Using UIKit components
 var body: some View {
-    AnimatedImage(name: "animation2.gif") // Just for showcase, don't mix them at the same time
+    AnimatedImage(name: "animation2.gif") 
     .indicator(SDWebImageProgressIndicator.default) // UIKit indicator component
-    .indicator(Indicator.progress) // SwiftUI indicator component
     .transition(SDWebImageTransition.flipFromLeft) // UIKit animation transition
+}
+
+// Using SwiftUI components
+var body: some View {
+    AnimatedImage(name: "animation2.gif")
+    .indicator(Indicator.progress) // SwiftUI indicator component
     .transition(AnyTransition.flipFromLeft) // SwiftUI animation transition
 }
 ```

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ var body: some View {
         .playbackRate(2.0) // Playback speed rate
         
         // Bundle (not Asset Catalog)
-        AnimatedImage(name: "animation1", isAnimating: $isAnimating) // Animation control binding
+        AnimatedImage(name: "animation1.gif", isAnimating: $isAnimating) // Animation control binding
         .maxBufferSize(.max)
         .onViewUpdate { view, context in // Advanced native view coordinate
             // AppKit tooltip for mouse hover
@@ -230,7 +230,7 @@ Note: some of methods on `AnimatedImage` will return `some View`, a new Modified
 
 ```swift
 var body: some View {
-    AnimatedImage(name: "animation2") // Just for showcase, don't mix them at the same time
+    AnimatedImage(name: "animation2.gif") // Just for showcase, don't mix them at the same time
     .indicator(SDWebImageProgressIndicator.default) // UIKit indicator component
     .indicator(Indicator.progress) // SwiftUI indicator component
     .transition(SDWebImageTransition.flipFromLeft) // UIKit animation transition


### PR DESCRIPTION
This PR adds some corrections and readability improvements to the `AnimatedImage` section in Readme.

Apparently writing the file extension (e.g. `animation1.gif` instead of just `animation1`) is necessary. Otherwise the animated image is not visible at all.

An erroneous close parenthesis is fixed as well.