### PR TITLE
Fix iOS 16 undefined behavior warnings

### DIFF
--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -154,13 +154,14 @@ public struct WebImage : View {
     /// Animated Image Support
     func setupPlayer() -> some View {
         if let currentFrame = imagePlayer.currentFrame {
-            return configure(image: currentFrame)
+            return configure(image: currentFrame).onAppear()
         } else {
-            if let animatedImage = imageManager.image as? SDAnimatedImageProvider {
-                self.imagePlayer.setupPlayer(animatedImage: animatedImage)
-                self.imagePlayer.startPlaying()
+            return configure(image: imageManager.image!).onAppear {
+                if let animatedImage = imageManager.image as? SDAnimatedImageProvider {
+                    self.imagePlayer.setupPlayer(animatedImage: animatedImage)
+                    self.imagePlayer.startPlaying()
+                }
             }
-            return configure(image: imageManager.image!)
         }
     }
     

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -52,6 +52,11 @@ public struct WebImage : View {
         }
         self.imageManager = ImageManager(url: url, options: options, context: context)
         self.imagePlayer = ImagePlayer()
+        
+        // This solve the case when WebImage created with new URL, but `onAppear` not been called, for example, some transaction indeterminate state, SwiftUI :)
+        if imageManager.isFirstLoad {
+            imageManager.load()
+        }
     }
     
     public var body: some View {


### PR DESCRIPTION
Fixes warnings triggered by bad state updates mentioned in https://github.com/SDWebImage/SDWebImageSwiftUI/issues/222

Not tested with AppKit and could use the input of someone familiar with `SwiftUICompatibility.swift` (this removes usage)