### PR TITLE
Fix iOS 13 compatibility && State changes

### DIFF
--- a/Example/SDWebImageSwiftUI.xcodeproj/project.pbxproj
+++ b/Example/SDWebImageSwiftUI.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		322E0E2228D332130003A55F /* Images.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 322E0DF228D331A20003A55F /* Images.bundle */; };
 		322E0E2328D332130003A55F /* Images.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 322E0DF228D331A20003A55F /* Images.bundle */; };
 		326B0D712345C01900D28269 /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326B0D702345C01900D28269 /* DetailView.swift */; };
+		327B90F228DC4EBB003E8BD9 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 327B90F128DC4EBB003E8BD9 /* ViewInspector */; };
+		327B90F428DC4EC0003E8BD9 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 327B90F328DC4EC0003E8BD9 /* ViewInspector */; };
 		32DCFE9528D333E8001A17BF /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = 32DCFE9428D333E8001A17BF /* ViewInspector */; };
 		32E5290C2348A0C700EA46FF /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E5290B2348A0C700EA46FF /* AppDelegate.swift */; };
 		32E529102348A0C900EA46FF /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 32E5290F2348A0C900EA46FF /* Assets.xcassets */; };
@@ -220,6 +222,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				833A61715BAAB31702D867CC /* Pods_SDWebImageSwiftUITests_macOS.framework in Frameworks */,
+				327B90F228DC4EBB003E8BD9 /* ViewInspector in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,6 +231,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2E3D81A12C757E01A3C420F2 /* Pods_SDWebImageSwiftUITests_tvOS.framework in Frameworks */,
+				327B90F428DC4EC0003E8BD9 /* ViewInspector in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -517,9 +521,13 @@
 			buildRules = (
 			);
 			dependencies = (
+				327B90EE28DC4EAA003E8BD9 /* PBXTargetDependency */,
 				322E0E0728D331F00003A55F /* PBXTargetDependency */,
 			);
 			name = "SDWebImageSwiftUITests macOS";
+			packageProductDependencies = (
+				327B90F128DC4EBB003E8BD9 /* ViewInspector */,
+			);
 			productName = "SDWebImageSwiftUITests macOS";
 			productReference = 322E0E0228D331F00003A55F /* SDWebImageSwiftUITests macOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -537,9 +545,13 @@
 			buildRules = (
 			);
 			dependencies = (
+				327B90F028DC4EAE003E8BD9 /* PBXTargetDependency */,
 				322E0E1428D332050003A55F /* PBXTargetDependency */,
 			);
 			name = "SDWebImageSwiftUITests tvOS";
+			packageProductDependencies = (
+				327B90F328DC4EC0003E8BD9 /* ViewInspector */,
+			);
 			productName = "SDWebImageSwiftUITests tvOS";
 			productReference = 322E0E0F28D332050003A55F /* SDWebImageSwiftUITests tvOS.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -698,7 +710,7 @@
 			);
 			mainGroup = 607FACC71AFB9204008FA782;
 			packageReferences = (
-				32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector.git" */,
+				32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */,
 			);
 			productRefGroup = 607FACD11AFB9204008FA782 /* Products */;
 			projectDirPath = "";
@@ -1224,6 +1236,14 @@
 			isa = PBXTargetDependency;
 			target = 32E5291F2348A0D300EA46FF /* SDWebImageSwiftUIDemo-tvOS */;
 			targetProxy = 322E0E1328D332050003A55F /* PBXContainerItemProxy */;
+		};
+		327B90EE28DC4EAA003E8BD9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 327B90ED28DC4EAA003E8BD9 /* ViewInspector */;
+		};
+		327B90F028DC4EAE003E8BD9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 327B90EF28DC4EAE003E8BD9 /* ViewInspector */;
 		};
 		32DCFE9728D333F1001A17BF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2044,7 +2064,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector.git" */ = {
+		32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/nalexn/ViewInspector.git";
 			requirement = {
@@ -2055,14 +2075,34 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		327B90ED28DC4EAA003E8BD9 /* ViewInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */;
+			productName = ViewInspector;
+		};
+		327B90EF28DC4EAE003E8BD9 /* ViewInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */;
+			productName = ViewInspector;
+		};
+		327B90F128DC4EBB003E8BD9 /* ViewInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */;
+			productName = ViewInspector;
+		};
+		327B90F328DC4EC0003E8BD9 /* ViewInspector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */;
+			productName = ViewInspector;
+		};
 		32DCFE9428D333E8001A17BF /* ViewInspector */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector.git" */;
+			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */;
 			productName = ViewInspector;
 		};
 		32DCFE9628D333F1001A17BF /* ViewInspector */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector.git" */;
+			package = 32DCFE8D28D333B0001A17BF /* XCRemoteSwiftPackageReference "ViewInspector" */;
 			productName = ViewInspector;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -65,6 +65,10 @@ struct ContentView2: View {
                     imageIndex += 1
                 }
             }
+            Button("Reload") {
+                SDImageCache.shared.clearMemory()
+                SDImageCache.shared.clearDisk(onCompletion: nil)
+            }
             Toggle("Switch", isOn: $animated)
         }
     }

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -48,6 +48,11 @@ struct ContentView2: View {
         Group {
             Text("\(animated ? "AnimatedImage" : "WebImage") - \((imageURLs[imageIndex] as NSString).lastPathComponent)")
             Spacer()
+            #if os(watchOS)
+            WebImage(url:URL(string: imageURLs[imageIndex]))
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            #else
             if self.animated {
                 AnimatedImage(url:URL(string: imageURLs[imageIndex]))
                 .resizable()
@@ -57,6 +62,7 @@ struct ContentView2: View {
                 .resizable()
                 .aspectRatio(contentMode: .fit)
             }
+            #endif
             Spacer()
             Button("Next") {
                 if imageIndex + 1 >= imageURLs.count {

--- a/Example/SDWebImageSwiftUIDemo/ContentView.swift
+++ b/Example/SDWebImageSwiftUIDemo/ContentView.swift
@@ -34,6 +34,42 @@ extension Indicator where T == ProgressView<EmptyView, EmptyView> {
 }
 #endif
 
+// Test Switching url using @State
+struct ContentView2: View {
+    @State var imageURLs = [
+        "https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_1.jpg",
+        "https://raw.githubusercontent.com/recurser/exif-orientation-examples/master/Landscape_2.jpg",
+        "http://assets.sbnation.com/assets/2512203/dogflops.gif",
+        "https://raw.githubusercontent.com/liyong03/YLGIFImage/master/YLGIFImageDemo/YLGIFImageDemo/joy.gif"
+    ]
+    @State var animated: Bool = false // You can change between WebImage/AnimatedImage
+    @State var imageIndex : Int = 0
+    var body: some View {
+        Group {
+            Text("\(animated ? "AnimatedImage" : "WebImage") - \((imageURLs[imageIndex] as NSString).lastPathComponent)")
+            Spacer()
+            if self.animated {
+                AnimatedImage(url:URL(string: imageURLs[imageIndex]))
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+            } else {
+                WebImage(url:URL(string: imageURLs[imageIndex]))
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+            }
+            Spacer()
+            Button("Next") {
+                if imageIndex + 1 >= imageURLs.count {
+                    imageIndex = 0
+                } else {
+                    imageIndex += 1
+                }
+            }
+            Toggle("Switch", isOn: $animated)
+        }
+    }
+}
+
 struct ContentView: View {
     @State var imageURLs = [
     "http://assets.sbnation.com/assets/2512203/dogflops.gif",

--- a/SDWebImageSwiftUI.xcodeproj/project.pbxproj
+++ b/SDWebImageSwiftUI.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		326E480B23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E480923431C0F00C633E9 /* ImageViewWrapper.swift */; };
 		326E480C23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E480923431C0F00C633E9 /* ImageViewWrapper.swift */; };
 		326E480D23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E480923431C0F00C633E9 /* ImageViewWrapper.swift */; };
+		32B79C9528DB40430088C432 /* SwiftUICompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B79C9428DB40430088C432 /* SwiftUICompatibility.swift */; };
+		32B79C9628DB40430088C432 /* SwiftUICompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B79C9428DB40430088C432 /* SwiftUICompatibility.swift */; };
+		32B79C9728DB40430088C432 /* SwiftUICompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B79C9428DB40430088C432 /* SwiftUICompatibility.swift */; };
+		32B79C9828DB40430088C432 /* SwiftUICompatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B79C9428DB40430088C432 /* SwiftUICompatibility.swift */; };
 		32B933E523659A1900BB7CAD /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B933E423659A1900BB7CAD /* Transition.swift */; };
 		32B933E623659A1900BB7CAD /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B933E423659A1900BB7CAD /* Transition.swift */; };
 		32B933E723659A1900BB7CAD /* Transition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32B933E423659A1900BB7CAD /* Transition.swift */; };
@@ -87,6 +91,7 @@
 		326B8486236335110011BDFB /* ActivityIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
 		326B848B236335400011BDFB /* ProgressIndicator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressIndicator.swift; sourceTree = "<group>"; };
 		326E480923431C0F00C633E9 /* ImageViewWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageViewWrapper.swift; sourceTree = "<group>"; };
+		32B79C9428DB40430088C432 /* SwiftUICompatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwiftUICompatibility.swift; sourceTree = "<group>"; };
 		32B933E423659A1900BB7CAD /* Transition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Transition.swift; sourceTree = "<group>"; };
 		32BC086F28D23D35002451BD /* StateObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StateObject.swift; sourceTree = "<group>"; };
 		32BC087028D23D35002451BD /* OnChange.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnChange.swift; sourceTree = "<group>"; };
@@ -233,6 +238,7 @@
 				32C43DDE22FD54C600BE87F5 /* WebImage.swift */,
 				32C43DDF22FD54C600BE87F5 /* AnimatedImage.swift */,
 				32C43E3122FD5DE100BE87F5 /* SDWebImageSwiftUI.swift */,
+				32B79C9428DB40430088C432 /* SwiftUICompatibility.swift */,
 				326E480923431C0F00C633E9 /* ImageViewWrapper.swift */,
 				32D26A012446B546005905DA /* Image.swift */,
 			);
@@ -457,6 +463,7 @@
 				326B84822363350C0011BDFB /* Indicator.swift in Sources */,
 				32C43E3222FD5DE100BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
 				326E480A23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
+				32B79C9528DB40430088C432 /* SwiftUICompatibility.swift in Sources */,
 				326B8487236335110011BDFB /* ActivityIndicator.swift in Sources */,
 				32C43E1622FD583700BE87F5 /* ImageManager.swift in Sources */,
 				32C43E1822FD583700BE87F5 /* AnimatedImage.swift in Sources */,
@@ -479,6 +486,7 @@
 				326B84832363350C0011BDFB /* Indicator.swift in Sources */,
 				32C43E3322FD5DF400BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
 				326E480B23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
+				32B79C9628DB40430088C432 /* SwiftUICompatibility.swift in Sources */,
 				326B8488236335110011BDFB /* ActivityIndicator.swift in Sources */,
 				32C43E1922FD583700BE87F5 /* ImageManager.swift in Sources */,
 				32C43E1B22FD583700BE87F5 /* AnimatedImage.swift in Sources */,
@@ -501,6 +509,7 @@
 				326B84842363350C0011BDFB /* Indicator.swift in Sources */,
 				32C43E3422FD5DF400BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
 				326E480C23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
+				32B79C9728DB40430088C432 /* SwiftUICompatibility.swift in Sources */,
 				326B8489236335110011BDFB /* ActivityIndicator.swift in Sources */,
 				32C43E1C22FD583800BE87F5 /* ImageManager.swift in Sources */,
 				32C43E1E22FD583800BE87F5 /* AnimatedImage.swift in Sources */,
@@ -523,6 +532,7 @@
 				326B84852363350C0011BDFB /* Indicator.swift in Sources */,
 				32C43E3522FD5DF400BE87F5 /* SDWebImageSwiftUI.swift in Sources */,
 				326E480D23431C0F00C633E9 /* ImageViewWrapper.swift in Sources */,
+				32B79C9828DB40430088C432 /* SwiftUICompatibility.swift in Sources */,
 				326B848A236335110011BDFB /* ActivityIndicator.swift in Sources */,
 				32C43E1F22FD583800BE87F5 /* ImageManager.swift in Sources */,
 				32C43E2122FD583800BE87F5 /* AnimatedImage.swift in Sources */,

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -101,15 +101,7 @@ final class AnimatedImageConfiguration: ObservableObject {
 /// A Image View type to load image from url, data or bundle. Supports animated and static image format.
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct AnimatedImage : PlatformViewRepresentable {
-    @SwiftUI.StateObject var imageModel_SwiftUI = AnimatedImageModel()
-    @Backport.StateObject var imageModel_Backport = AnimatedImageModel()
-    var imageModel: AnimatedImageModel {
-        if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
-            return imageModel_SwiftUI
-        } else {
-            return imageModel_Backport
-        }
-    }
+    @ObservedObject var imageModel: AnimatedImageModel
     @ObservedObject var imageHandler = AnimatedImageHandler()
     @ObservedObject var imageLayout = AnimatedImageLayout()
     @ObservedObject var imageConfiguration = AnimatedImageConfiguration()
@@ -186,11 +178,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
     
     init(imageModel: AnimatedImageModel, isAnimating: Binding<Bool>) {
         self._isAnimating = isAnimating
-        if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
-            _imageModel_SwiftUI = SwiftUI.StateObject(wrappedValue: imageModel)
-        } else {
-            _imageModel_Backport = Backport.StateObject(wrappedValue: imageModel)
-        }
+        _imageModel = ObservedObject(wrappedValue: imageModel)
     }
     
     #if os(macOS)

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -101,6 +101,7 @@ public final class ImageManager : ObservableObject {
             currentOperation = nil
         }
         indicatorStatus.isLoading = false
+        currentURL = nil
     }
     
 }

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -28,37 +28,24 @@ public final class ImageManager : ObservableObject {
     /// true means during incremental loading
     @Published public var isIncremental: Bool = false
     
-    var manager: SDWebImageManager?
     weak var currentOperation: SDWebImageOperation? = nil
     
-    var url: URL?
-    var options: SDWebImageOptions = []
-    var context: [SDWebImageContextOption : Any]? = nil
     var successBlock: ((PlatformImage, Data?, SDImageCacheType) -> Void)?
     var failureBlock: ((Error) -> Void)?
     var progressBlock: ((Int, Int) -> Void)?
     
-    /// Create a image manager for loading the specify url, with custom options and context.
+    public init() {}
+    
+    /// Start to load the url operation
     /// - Parameter url: The image url
     /// - Parameter options: The options to use when downloading the image. See `SDWebImageOptions` for the possible values.
     /// - Parameter context: A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
-    public init(url: URL?, options: SDWebImageOptions = [], context: [SDWebImageContextOption : Any]? = nil) {
-        self.url = url
-        self.options = options
-        self.context = context
-        if let manager = context?[.customManager] as? SDWebImageManager {
-            self.manager = manager
+    public func load(url: URL?, options: SDWebImageOptions = [], context: [SDWebImageContextOption : Any]? = nil) {
+        let manager: SDWebImageManager
+        if let customManager = context?[.customManager] as? SDWebImageManager {
+            manager = customManager
         } else {
-            self.manager = .shared
-        }
-    }
-    
-    init() {}
-    
-    /// Start to load the url operation
-    public func load() {
-        guard let manager = manager else {
-            return
+            manager = .shared
         }
         if currentOperation != nil {
             return

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -27,7 +27,8 @@ public final class ImageManager : ObservableObject {
     @Published public var indicatorStatus = IndicatorStatus()
     
     weak var currentOperation: SDWebImageOperation? = nil
-    
+
+    var currentURL: URL?
     var successBlock: ((PlatformImage, Data?, SDImageCacheType) -> Void)?
     var failureBlock: ((Error) -> Void)?
     var progressBlock: ((Int, Int) -> Void)?
@@ -45,10 +46,12 @@ public final class ImageManager : ObservableObject {
         } else {
             manager = .shared
         }
-        if currentOperation != nil {
+        if (currentOperation != nil && currentURL == url) {
             return
         }
-        self.indicatorStatus.isLoading = true
+        currentURL = url
+        indicatorStatus.isLoading = true
+        indicatorStatus.progress = 0
         currentOperation = manager.loadImage(with: url, options: options, context: context, progress: { [weak self] (receivedSize, expectedSize, _) in
             guard let self = self else {
                 return

--- a/SDWebImageSwiftUI/Classes/ImagePlayer.swift
+++ b/SDWebImageSwiftUI/Classes/ImagePlayer.swift
@@ -45,6 +45,8 @@ public final class ImagePlayer : ObservableObject {
     /// Current playing loop count
     @Published public var currentLoopCount: UInt = 0
     
+    var currentAnimatedImage: (PlatformImage & SDAnimatedImageProvider)?
+    
     /// Whether current player is valid for playing. This will check the internal player exist or not
     public var isValid: Bool {
         player != nil
@@ -97,10 +99,11 @@ public final class ImagePlayer : ObservableObject {
     /// Setup the player using Animated Image.
     /// After setup, you can always check `isValid` status, or call `startPlaying` to play the animation.
     /// - Parameter image: animated image
-    public func setupPlayer(animatedImage: SDAnimatedImageProvider) {
+    public func setupPlayer(animatedImage: PlatformImage & SDAnimatedImageProvider) {
         if isValid {
             return
         }
+        currentAnimatedImage = animatedImage
         if let imagePlayer = SDAnimatedImagePlayer(provider: animatedImage) {
             imagePlayer.animationFrameHandler = { [weak self] (index, frame) in
                 self?.currentFrameIndex = index

--- a/SDWebImageSwiftUI/Classes/SwiftUICompatibility.swift
+++ b/SDWebImageSwiftUI/Classes/SwiftUICompatibility.swift
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the SDWebImage package.
+ * (c) DreamPiggy <lizhuoli1126@126.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import Foundation
+import SwiftUI
+
+#if os(iOS) || os(tvOS) || os(macOS)
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+struct PlatformAppear: PlatformViewRepresentable {
+    let appearAction: () -> Void
+    let disappearAction: () -> Void
+    
+    #if os(iOS) || os(tvOS)
+    func makeUIView(context: Context) -> some UIView {
+        let view = PlatformAppearView()
+        view.appearAction = appearAction
+        view.disappearAction = disappearAction
+        return view
+    }
+    
+    func updateUIView(_ uiView: UIViewType, context: Context) {}
+    #endif
+    #if os(macOS)
+    func makeNSView(context: Context) -> some NSView {
+        let view = PlatformAppearView()
+        view.appearAction = appearAction
+        view.disappearAction = disappearAction
+        return view
+    }
+    
+    func updateNSView(_ nsView: NSViewType, context: Context) {}
+    #endif
+}
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+class PlatformAppearView: PlatformView {
+    var appearAction: () -> Void = {}
+    var disappearAction: () -> Void = {}
+    
+    #if os(iOS) || os(tvOS)
+    override func willMove(toWindow newWindow: UIWindow?) {
+        if newWindow != nil {
+            appearAction()
+        } else {
+            disappearAction()
+        }
+    }
+    #endif
+    
+    #if os(macOS)
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        if newWindow != nil {
+            appearAction()
+        } else {
+            disappearAction()
+        }
+    }
+    #endif
+}
+
+#endif
+
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+extension View {
+    /// Used UIKit/AppKit behavior to detect the SwiftUI view's visibility.
+    /// This hack is because of SwiftUI 1.0/2.0 buggy behavior. The built-in `onAppear` and `onDisappear` is so massive on some cases. Where UIKit/AppKit is solid.
+    /// - Parameters:
+    ///   - appear: The action when view appears
+    ///   - disappear: The action when view disappears
+    /// - Returns: Some view
+    func onPlatformAppear(appear: @escaping () -> Void = {}, disappear: @escaping () -> Void = {}) -> some View {
+        #if os(iOS) || os(tvOS) || os(macOS)
+        return self.background(PlatformAppear(appearAction: appear, disappearAction: disappear))
+        #else
+        return self.onAppear(perform: appear).onDisappear(perform: disappear)
+        #endif
+    }
+}

--- a/SDWebImageSwiftUI/Classes/SwiftUICompatibility.swift
+++ b/SDWebImageSwiftUI/Classes/SwiftUICompatibility.swift
@@ -84,7 +84,7 @@ extension View {
     /// - Returns: Some view
     func onPlatformAppear(appear: @escaping () -> Void = {}, disappear: @escaping () -> Void = {}) -> some View {
         #if os(iOS) || os(tvOS) || os(macOS)
-        return self.overlay(PlatformAppear(appearAction: appear, disappearAction: disappear))
+        return self.background(PlatformAppear(appearAction: appear, disappearAction: disappear))
         #else
         return self.onAppear(perform: appear).onDisappear(perform: disappear)
         #endif

--- a/SDWebImageSwiftUI/Classes/SwiftUICompatibility.swift
+++ b/SDWebImageSwiftUI/Classes/SwiftUICompatibility.swift
@@ -46,9 +46,13 @@ class PlatformAppearView: PlatformView {
     #if os(iOS) || os(tvOS)
     override func willMove(toWindow newWindow: UIWindow?) {
         if newWindow != nil {
-            appearAction()
+            DispatchQueue.main.async {
+                self.appearAction()
+            }
         } else {
-            disappearAction()
+            DispatchQueue.main.async {
+                self.disappearAction()
+            }
         }
     }
     #endif
@@ -56,9 +60,13 @@ class PlatformAppearView: PlatformView {
     #if os(macOS)
     override func viewWillMove(toWindow newWindow: NSWindow?) {
         if newWindow != nil {
-            appearAction()
+            DispatchQueue.main.async {
+                self.appearAction()
+            }
         } else {
-            disappearAction()
+            DispatchQueue.main.async {
+                self.disappearAction()
+            }
         }
     }
     #endif
@@ -76,7 +84,7 @@ extension View {
     /// - Returns: Some view
     func onPlatformAppear(appear: @escaping () -> Void = {}, disappear: @escaping () -> Void = {}) -> some View {
         #if os(iOS) || os(tvOS) || os(macOS)
-        return self.background(PlatformAppear(appearAction: appear, disappearAction: disappear))
+        return self.overlay(PlatformAppear(appearAction: appear, disappearAction: disappear))
         #else
         return self.onAppear(perform: appear).onDisappear(perform: disappear)
         #endif

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -61,9 +61,6 @@ public struct WebImage : View {
     /// A observed object to pass through the image configuration to player
     @ObservedObject var imageConfiguration = WebImageConfiguration()
     
-    /// A observed object to pass through the image manager loading status to indicator
-    @ObservedObject var indicatorStatus = IndicatorStatus()
-    
     @ObservedObject var imagePlayer = ImagePlayer()
     
     // FIXME: Use SwiftUI StateObject and remove onPlatformAppear once drop iOS 13 support
@@ -142,10 +139,7 @@ public struct WebImage : View {
                     if self.imageManager.image == nil && !self.imageManager.isIncremental {
                         self.imageManager.cancel()
                     }
-                }).onReceive(imageManager.objectWillChange) { _ in
-                    indicatorStatus.isLoading = imageManager.isLoading
-                    indicatorStatus.progress = imageManager.progress
-                }
+                })
             }
         }
     }
@@ -225,7 +219,7 @@ public struct WebImage : View {
         // Don't use `Group` because it will trigger `.onAppear` and `.onDisappear` when condition view removed, treat placeholder as an entire component
         if let placeholder = placeholder {
             // If use `.delayPlaceholder`, the placeholder is applied after loading failed, hide during loading :)
-            if imageModel.webOptions.contains(.delayPlaceholder) && imageManager.isLoading {
+            if imageModel.webOptions.contains(.delayPlaceholder) && imageManager.indicatorStatus.isLoading {
                 return AnyView(configure(image: .empty))
             } else {
                 return placeholder
@@ -352,7 +346,7 @@ extension WebImage {
     /// Associate a indicator when loading image with url
     /// - Parameter indicator: The indicator type, see `Indicator`
     public func indicator<T>(_ indicator: Indicator<T>) -> some View where T : View {
-        return self.modifier(IndicatorViewModifier(status: indicatorStatus, indicator: indicator))
+        return self.modifier(IndicatorViewModifier(status: imageManager.indicatorStatus, indicator: indicator))
     }
     
     /// Associate a indicator when loading image with url, convenient method with block

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -253,16 +253,20 @@ public struct WebImage : View {
     /// Placeholder View Support
     func setupPlaceholder() -> some View {
         // Don't use `Group` because it will trigger `.onAppear` and `.onDisappear` when condition view removed, treat placeholder as an entire component
+        let result: AnyView
         if let placeholder = placeholder {
             // If use `.delayPlaceholder`, the placeholder is applied after loading failed, hide during loading :)
             if imageModel.options.contains(.delayPlaceholder) && imageManager.error == nil {
-                return AnyView(configure(image: .empty).id(UUID())) // UUID to avoid SwiftUI engine cache the status and does not call `onAppear`
+                result = AnyView(configure(image: .empty))
             } else {
-                return placeholder
+                result = placeholder
             }
         } else {
-            return AnyView(configure(image: .empty).id(UUID())) // UUID to avoid SwiftUI engine cache the status and does not call `onAppear`
+            result = AnyView(configure(image: .empty))
         }
+        // UUID to avoid SwiftUI engine cache the status, and does not call `onAppear` when placeholder not changed (See `ContentView.swift/ContentView2` case)
+        // Because we load the image url in `onAppear`, it should be called to sync with state changes :)
+        return result.id(UUID())
     }
 }
 

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -61,7 +61,8 @@ public struct WebImage : View {
     /// A observed object to pass through the image configuration to player
     @ObservedObject var imageConfiguration = WebImageConfiguration()
     
-    @ObservedObject var imagePlayer = ImagePlayer()
+    // FIXME: Use SwiftUI StateObject and remove onPlatformAppear once drop iOS 13 support
+    @Backport.StateObject var imagePlayer = ImagePlayer()
     
     // FIXME: Use SwiftUI StateObject and remove onPlatformAppear once drop iOS 13 support
     @Backport.StateObject var imageManager = ImageManager()
@@ -219,7 +220,7 @@ public struct WebImage : View {
         // Don't use `Group` because it will trigger `.onAppear` and `.onDisappear` when condition view removed, treat placeholder as an entire component
         if let placeholder = placeholder {
             // If use `.delayPlaceholder`, the placeholder is applied after loading failed, hide during loading :)
-            if imageModel.webOptions.contains(.delayPlaceholder) && imageManager.indicatorStatus.isLoading {
+            if imageModel.webOptions.contains(.delayPlaceholder) && imageManager.error == nil {
                 return AnyView(configure(image: .empty))
             } else {
                 return placeholder

--- a/Tests/AnimatedImageTests.swift
+++ b/Tests/AnimatedImageTests.swift
@@ -182,7 +182,7 @@ class AnimatedImageTests: XCTestCase {
         .animation(.easeInOut)
         _ = try introspectView.inspect()
         ViewHosting.host(view: introspectView)
-        self.waitForExpectations(timeout: 5, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
         ViewHosting.expel()
     }
 }

--- a/Tests/ImageManagerTests.swift
+++ b/Tests/ImageManagerTests.swift
@@ -18,7 +18,7 @@ class ImageManagerTests: XCTestCase {
     func testImageManager() throws {
         let expectation = self.expectation(description: "ImageManager usage with Combine")
         let imageUrl = URL(string: "https://via.placeholder.com/500x500.jpg")
-        let imageManager = ImageManager(url: imageUrl)
+        let imageManager = ImageManager()
         imageManager.setOnSuccess { image, cacheType, data in
             XCTAssertNotNil(image)
             expectation.fulfill()
@@ -29,7 +29,7 @@ class ImageManagerTests: XCTestCase {
         imageManager.setOnProgress { receivedSize, expectedSize in
             
         }
-        imageManager.load()
+        imageManager.load(url: imageUrl)
         XCTAssertNotNil(imageManager.currentOperation)
         let sub = imageManager.objectWillChange
             .subscribe(on: RunLoop.main)

--- a/Tests/ImageManagerTests.swift
+++ b/Tests/ImageManagerTests.swift
@@ -38,6 +38,6 @@ class ImageManagerTests: XCTestCase {
                 print(value)
         }
         sub.cancel()
-        self.waitForExpectations(timeout: 5, handler: nil)
+        self.waitForExpectations(timeout: 10, handler: nil)
     }
 }

--- a/Tests/WebImageTests.swift
+++ b/Tests/WebImageTests.swift
@@ -23,7 +23,7 @@ class WebImageTests: XCTestCase {
         let imageView = WebImage(url: imageUrl)
         let introspectView = imageView.onSuccess { image, data, cacheType in
             #if os(macOS)
-            let displayImage = try? imageView.inspect().group().image(0).actualImage.nsImage()
+            let displayImage = try? imageView.inspect().group().image(0).actualImage().nsImage()
             #else
             let displayImage = try? imageView.inspect().group().image(0).actualImage().cgImage()
             #endif


### PR DESCRIPTION
### Changes
1. Revert back the onPlatformAppear to fix iOS 14+ behavior Use backport for all OSs
2. `ImageManager` API changes. The `init` method has no args, use `load(url:options:context:)` instead


This PR close #230 close #229 close #228

As for now, Swift still can not use different stored property on different availability check OS Host. This is runtime limit. Previous #227 will cause a Swift runtime crash when demangling symbols from iOS 13+

So, I just remove the `SwiftUI.StateObject` references and use Backport + PlatformAppear hack (Because `SwiftUI.List` 's `onAppear` does not works as expected when using non `SwiftUI.StateObject`)

v3.0.0 will remove iOS 13 support.