### PR TITLE
update Published properties of ImageManager in the main thread

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -63,7 +63,9 @@ public final class ImageManager : ObservableObject {
         if currentOperation != nil {
             return
         }
-        self.isLoading = true
+        DispatchQueue.main.async {
+            self.isLoading = true
+        }
         currentOperation = manager.loadImage(with: url, options: options, context: context, progress: { [weak self] (receivedSize, expectedSize, _) in
             guard let self = self else {
                 return
@@ -89,14 +91,18 @@ public final class ImageManager : ObservableObject {
                 // So previous View struct call `onDisappear` and cancel the currentOperation
                 return
             }
-            self.image = image
-            self.error = error
-            self.isIncremental = !finished
+            DispatchQueue.main.async {
+                self.image = image
+                self.error = error
+                self.isIncremental = !finished
+            }
             if finished {
-                self.imageData = data
-                self.cacheType = cacheType
-                self.isLoading = false
-                self.progress = 1
+                DispatchQueue.main.async {
+                    self.imageData = data
+                    self.cacheType = cacheType
+                    self.isLoading = false
+                    self.progress = 1
+                }
                 if let image = image {
                     self.successBlock?(image, data, cacheType)
                 } else {


### PR DESCRIPTION
## What?
update `Published` properties of `ImageManager` in the main thread

## Why?

Publishing changes from background threads is not allowed; make sure to publish values from the main thread.

## How?

As a temporary solution, enforcing assigning new values in the main thread but ideally it should be done via subscription to model changes and triggering changes as e response. i.e. via PassthroughSubject and operators like receive(on:)).

<img width="1327" alt="Screen Shot 2022-09-21 at 8 42 54 pm" src="https://user-images.githubusercontent.com/61129855/191511810-9a4f902c-5ae1-40af-b172-4d8cf8ff907f.png">
