### PR TITLE
Fix the nil url always returns Error will cause infinity `onAppear` call and image manager to load, which waste CPU

### DIFF
--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -264,9 +264,9 @@ public struct WebImage : View {
         } else {
             result = AnyView(configure(image: .empty))
         }
-        // UUID to avoid SwiftUI engine cache the status, and does not call `onAppear` when placeholder not changed (See `ContentView.swift/ContentView2` case)
-        // Because we load the image url in `onAppear`, it should be called to sync with state changes :)
-        return result.id(UUID())
+        // Custom ID to avoid SwiftUI engine cache the status, and does not call `onAppear` when placeholder not changed (See `ContentView.swift/ContentView2` case)
+        // Because we load the image url in placeholder's `onAppear`, it should be called to sync with state changes :)
+        return result.id(imageModel.url)
     }
 }
 


### PR DESCRIPTION
closing #234 

### Background

This is because the fixed-point logic driver by SwiftUI, will recursivelly trigger placeholder's `onAppear` (because v2.2.0 use UUID as ID for placeholder), and trigger the ImageManager to load and always failed immediately, trigger another else condition in View.body, and another `setupPlaceholder && ImageManager load`, finally may consuming CPU because it's un-ended.

This fix use the URL as ID, if the nil url is provided, only one `onAppear` will trigger, so it's end.

### Tips

Also, I think the nil URL design is a bad design for SwiftUI, but good design for UIKit.

Although it's introduced from #2 , may removed in the future