### PR TITLE
Fix the case which sometimes the player does not stop when WebImage it out of screen

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImagePlayer.swift
+++ b/SDWebImageSwiftUI/Classes/ImagePlayer.swift
@@ -33,7 +33,6 @@ public final class ImagePlayer : ObservableObject {
     
     deinit {
         player?.stopPlaying()
-        currentFrame = nil
     }
     
     /// Current playing frame image
@@ -57,7 +56,7 @@ public final class ImagePlayer : ObservableObject {
         if let player = player {
             return player.isPlaying && waitingPlaying
         }
-        return false
+        return true
     }
     
     /// Current playing status

--- a/SDWebImageSwiftUI/Classes/ImagePlayer.swift
+++ b/SDWebImageSwiftUI/Classes/ImagePlayer.swift
@@ -105,11 +105,21 @@ public final class ImagePlayer : ObservableObject {
         currentAnimatedImage = animatedImage
         if let imagePlayer = SDAnimatedImagePlayer(provider: animatedImage) {
             imagePlayer.animationFrameHandler = { [weak self] (index, frame) in
-                self?.currentFrameIndex = index
-                self?.currentFrame = frame
+                guard let self = self else {
+                    return
+                }
+                if (self.isPlaying) {
+                    self.currentFrameIndex = index
+                    self.currentFrame = frame
+                }
             }
             imagePlayer.animationLoopHandler = { [weak self] (loopCount) in
-                self?.currentLoopCount = loopCount
+                guard let self = self else {
+                    return
+                }
+                if (self.isPlaying) {
+                    self.currentLoopCount = loopCount
+                }
             }
             // Setup configuration
             if let maxBufferSize = maxBufferSize {

--- a/Tests/WebImageTests.swift
+++ b/Tests/WebImageTests.swift
@@ -23,9 +23,9 @@ class WebImageTests: XCTestCase {
         let imageView = WebImage(url: imageUrl)
         let introspectView = imageView.onSuccess { image, data, cacheType in
             #if os(macOS)
-            let displayImage = try? imageView.inspect().group().image(0).actualImage().nsImage()
+            let displayImage = try? imageView.inspect().zStack().image(1).actualImage().nsImage()
             #else
-            let displayImage = try? imageView.inspect().group().image(0).actualImage().cgImage()
+            let displayImage = try? imageView.inspect().zStack().image(1).actualImage().cgImage()
             #endif
             XCTAssertNotNil(displayImage)
             expectation.fulfill()
@@ -47,10 +47,10 @@ class WebImageTests: XCTestCase {
             if let animatedImage = image as? SDAnimatedImage {
                 XCTAssertTrue(imageView.isAnimating)
                 #if os(macOS)
-                let displayImage = try? imageView.inspect().group().image(0).actualImage().nsImage()
+                let displayImage = try? imageView.inspect().zStack().image(1).actualImage().nsImage()
                 let size = displayImage?.size
                 #else
-                let displayImage = try? imageView.inspect().group().image(0).actualImage().cgImage()
+                let displayImage = try? imageView.inspect().zStack().image(1).actualImage().cgImage()
                 let size = CGSize(width: displayImage?.width ?? 0, height: displayImage?.height ?? 0)
                 #endif
                 XCTAssertNotNil(displayImage)
@@ -161,11 +161,11 @@ class WebImageTests: XCTestCase {
         let imageView = WebImage(url: imageUrl)
         let introspectView = imageView.onSuccess { image, data, cacheType in
             #if os(macOS)
-            let displayImage = try? imageView.inspect().group().image(0).actualImage().nsImage()
+            let displayImage = try? imageView.inspect().zStack().image(1).actualImage().nsImage()
             XCTAssertNotNil(displayImage)
             #else
-            let displayImage = try? imageView.inspect().group().image(0).actualImage().cgImage()
-            let orientation = try? imageView.inspect().group().image(0).actualImage().orientation()
+            let displayImage = try? imageView.inspect().zStack().image(1).actualImage().cgImage()
+            let orientation = try? imageView.inspect().zStack().image(1).actualImage().orientation()
             XCTAssertNotNil(displayImage)
             XCTAssertEqual(orientation, .leftMirrored)
             #endif


### PR DESCRIPTION
This consume CPU because CADisplayLink is still running in the background

### Solution

Using the ZStack as a container to distinguish the container disappear vs frame disapppear

See: https://twitter.com/unixzii/status/1573281351939530752

### Demo
Pay attention to the CPU usage (compared to previous v2.2.0 behavior)

[demo.mov.zip](https://github.com/SDWebImage/SDWebImageSwiftUI/files/9633508/demo.mov.zip)

