### PR TITLE
Fixed SwiftUI View Update error in Xcode 14.0

### DIFF
--- a/Example/SDWebImageSwiftUI.xcodeproj/xcshareddata/xcschemes/SDWebImageSwiftUIDemo-watchOS WatchKit App.xcscheme
+++ b/Example/SDWebImageSwiftUI.xcodeproj/xcshareddata/xcschemes/SDWebImageSwiftUIDemo-watchOS WatchKit App.xcscheme
@@ -54,10 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/SDWebImageSwiftUIDemo-watchOS WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "32E529362348A0DD00EA46FF"
@@ -65,7 +63,7 @@
             BlueprintName = "SDWebImageSwiftUIDemo-watchOS WatchKit App"
             ReferencedContainer = "container:SDWebImageSwiftUI.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,10 +71,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/SDWebImageSwiftUIDemo-watchOS WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "32E529362348A0DD00EA46FF"
@@ -84,16 +80,7 @@
             BlueprintName = "SDWebImageSwiftUIDemo-watchOS WatchKit App"
             ReferencedContainer = "container:SDWebImageSwiftUI.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "32E529362348A0DD00EA46FF"
-            BuildableName = "SDWebImageSwiftUIDemo-watchOS WatchKit App.app"
-            BlueprintName = "SDWebImageSwiftUIDemo-watchOS WatchKit App"
-            ReferencedContainer = "container:SDWebImageSwiftUI.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -56,13 +56,13 @@ public final class ImageManager : ObservableObject {
             guard let self = self else {
                 return
             }
-            let progress: Double
-            if (expectedSize > 0) {
-                progress = Double(receivedSize) / Double(expectedSize)
-            } else {
-                progress = 0
-            }
             DispatchQueue.main.async {
+                let progress: Double
+                if (expectedSize > 0) {
+                    progress = Double(receivedSize) / Double(expectedSize)
+                } else {
+                    progress = 0
+                }
                 self.indicatorStatus.progress = progress
             }
             self.progressBlock?(receivedSize, expectedSize)
@@ -85,10 +85,12 @@ public final class ImageManager : ObservableObject {
                 self.cacheType = cacheType
                 self.indicatorStatus.isLoading = false
                 self.indicatorStatus.progress = 1
-                if let image = image {
-                    self.successBlock?(image, data, cacheType)
-                } else {
-                    self.failureBlock?(error ?? NSError())
+                DispatchQueue.main.async {
+                    if let image = image {
+                        self.successBlock?(image, data, cacheType)
+                    } else {
+                        self.failureBlock?(error ?? NSError())
+                    }
                 }
             }
         }


### PR DESCRIPTION
After updating to Xcode 14.0 and iOS 16 this package would spit out endless main thread warnings or "purple warnings" with the text:  `Publishing changes from within view updates is not allowed, this will cause undefined behavior `.  This request merely moves the offending code into the main thread on an asynchronous execution block. 

This was tested in an iOS App running on device and in simulator that had the endless main thread errors. After the changes in this branch, all main thread errors disappeared.