### PR TITLE
Fix the issue that Static Library + Library Evolution cause the build issue on Swift 5.8

### DIFF
--- a/SDWebImageSwiftUI.podspec
+++ b/SDWebImageSwiftUI.podspec
@@ -30,7 +30,6 @@ It brings all your favorite features from SDWebImage, like async image loading, 
   s.pod_target_xcconfig = {
     'SUPPORTS_MACCATALYST' => 'YES',
     'DERIVE_MACCATALYST_PRODUCT_BUNDLE_IDENTIFIER' => 'NO',
-    'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
   }
 
   s.weak_frameworks = 'SwiftUI', 'Combine'


### PR DESCRIPTION
# Changes
For CocoaPods user, they can use Static Library and we should not touch the xcconfig here

This close #259 #261 