### PR TITLE
Upgrade to support visionOS on CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ All issue reports, feature requests, contributions, and GitHub stars are welcome
 + macOS 11+
 + tvOS 14+
 + watchOS 7+
++ visionOS 1+
 
 ## for SwiftUI 1.0 (iOS 13)
 

--- a/SDWebImageSwiftUI.podspec
+++ b/SDWebImageSwiftUI.podspec
@@ -25,6 +25,7 @@ It brings all your favorite features from SDWebImage, like async image loading, 
   s.osx.deployment_target = '11.0'
   s.tvos.deployment_target = '14.0'
   s.watchos.deployment_target = '7.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source_files = 'SDWebImageSwiftUI/Classes/**/*', 'SDWebImageSwiftUI/Module/*.h'
   s.pod_target_xcconfig = {


### PR DESCRIPTION
Upgrade to support visionOS on CocoaPods

This is needed by SDWebImage Core Example

Just merge in and then release SDWebImage Core firstly