### PR TITLE
Fix AnimatedImage aspectRatio issue when ratio is nil

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -622,6 +622,11 @@ extension AnimatedImage {
 // Aspect Ratio
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 extension AnimatedImage {
+    func setImageLayoutAspectRatio(_ aspectRatio: CGFloat?, contentMode: ContentMode) {
+        self.imageLayout.aspectRatio = aspectRatio
+        self.imageLayout.contentMode = contentMode
+    }
+
     /// Constrains this view's dimensions to the specified aspect ratio.
     /// - Parameters:
     ///   - aspectRatio: The ratio of width to height to use for the resulting
@@ -631,6 +636,7 @@ extension AnimatedImage {
     ///     fill the parent context.
     /// - Returns: A view that constrains this view's dimensions to
     ///   `aspectRatio`, using `contentMode` as its scaling algorithm.
+    @ViewBuilder
     public func aspectRatio(_ aspectRatio: CGFloat? = nil, contentMode: ContentMode) -> some View {
         // The `SwifUI.View.aspectRatio(_:contentMode:)` says:
         // If `aspectRatio` is `nil`, the resulting view maintains this view's aspect ratio
@@ -640,9 +646,12 @@ extension AnimatedImage {
         // But 2: there are no way to call a Protocol Extention default implementation in Swift 5.1
         // So, we directly call the implementation detail modifier instead
         // Fired Radar: FB7413534
-        self.imageLayout.aspectRatio = aspectRatio
-        self.imageLayout.contentMode = contentMode
-        return self.modifier(_AspectRatioLayout(aspectRatio: aspectRatio, contentMode: contentMode))
+        let _ = self.setImageLayoutAspectRatio(aspectRatio, contentMode: contentMode)
+        if let aspectRatio {
+            self.modifier(_AspectRatioLayout(aspectRatio: aspectRatio, contentMode: contentMode))
+        } else {
+            self
+        }
     }
 
     /// Constrains this view's dimensions to the aspect ratio of the given size.


### PR DESCRIPTION
As reported by [hstdt](https://github.com/hstdt) on https://github.com/SDWebImage/SDWebImageSwiftUI/issues/279 removing `_AspectRatioLayout` modifier when `aspectRatio` is nil fixes the issue