### PR TITLE
Update version for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For downstream framework author, you should create a `Package.swift` file into y
 ```swift
 let package = Package(
     dependencies: [
-        .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI.git", from: "2.0.0")
+        .package(url: "https://github.com/SDWebImage/SDWebImageSwiftUI.git", from: "3.0.0")
     ],
 )
 ```


### PR DESCRIPTION
This PR updates the version for installation because SDWebImageSwiftUI 3.x has already been released.