### PR TITLE
Update platform names in `available` attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ class ViewController: UIViewController {
 }
 
 // ContentView.swift
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 struct ContentView : View {
     var body: some View {
         Group {

--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -12,7 +12,7 @@ import SDWebImage
 #if !os(watchOS)
 
 /// A coordinator object used for `AnimatedImage`native view  bridge for UIKit/AppKit.
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public final class AnimatedImageCoordinator: NSObject {
     
     /// Any user-provided object for actual coordinator, such as delegate method, taget-action
@@ -25,7 +25,7 @@ public final class AnimatedImageCoordinator: NSObject {
 }
 
 /// Data Binding Object, only properties in this object can support changes from user with @State and refresh
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class AnimatedImageModel : ObservableObject {
     enum Kind {
         case url
@@ -53,7 +53,7 @@ final class AnimatedImageModel : ObservableObject {
 }
 
 /// Loading Binding Object, only properties in this object can support changes from user with @State and refresh
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class AnimatedLoadingModel : ObservableObject {
     @Published var image: PlatformImage? // loaded image, note when progressive loading, this will published multiple times with different partial image
     @Published var isLoading: Bool = false // whether network is loading or cache is querying, should only be used for indicator binding
@@ -66,7 +66,7 @@ final class AnimatedLoadingModel : ObservableObject {
 }
 
 /// Completion Handler Binding Object, supports dynamic @State changes
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class AnimatedImageHandler: ObservableObject {
     // Completion Handler
     @Published var successBlock: ((PlatformImage, Data?, SDImageCacheType) -> Void)?
@@ -78,7 +78,7 @@ final class AnimatedImageHandler: ObservableObject {
 }
 
 /// Layout Binding Object, supports dynamic @State changes
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class AnimatedImageLayout : ObservableObject {
     var contentMode: ContentMode?
     var aspectRatio: CGFloat?
@@ -90,7 +90,7 @@ final class AnimatedImageLayout : ObservableObject {
 }
 
 /// Configuration Binding Object, supports dynamic @State changes
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class AnimatedImageConfiguration: ObservableObject {
     var incrementalLoad: Bool?
     var maxBufferSize: UInt?
@@ -106,7 +106,7 @@ final class AnimatedImageConfiguration: ObservableObject {
 }
 
 /// A Image View type to load image from url, data or bundle. Supports animated and static image format.
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct AnimatedImage : PlatformViewRepresentable {
     @ObservedObject var imageModel: AnimatedImageModel
     @ObservedObject var imageHandler = AnimatedImageHandler()
@@ -591,7 +591,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
 }
 
 // Layout
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension AnimatedImage {
     
     /// Configurate this view's image with the specified cap insets and options.
@@ -631,7 +631,7 @@ extension AnimatedImage {
 }
 
 // Aspect Ratio
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension AnimatedImage {
     func setImageLayoutAspectRatio(_ aspectRatio: CGFloat?, contentMode: ContentMode) {
         self.imageLayout.aspectRatio = aspectRatio
@@ -693,7 +693,7 @@ extension AnimatedImage {
 }
 
 // AnimatedImage Modifier
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension AnimatedImage {
     
     /// Total loop count for animated image rendering. Defaults to nil.
@@ -770,7 +770,7 @@ extension AnimatedImage {
 }
 
 // Completion Handler
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension AnimatedImage {
     
     /// Provide the action when image load fails.
@@ -802,7 +802,7 @@ extension AnimatedImage {
 }
 
 // View Coordinator Handler
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension AnimatedImage {
     
     /// Provide the action when view representable create the native view.
@@ -839,7 +839,7 @@ extension SDWebImageIndicator where Self == SDWebImageProgressIndicator {
 }
 
 // Web Image convenience, based on UIKit/AppKit API
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension AnimatedImage {
     
     /// Associate a indicator when loading image with url
@@ -860,7 +860,7 @@ extension AnimatedImage {
 }
 
 #if DEBUG
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 struct AnimatedImage_Previews : PreviewProvider {
     static var previews: some View {
         Group {

--- a/SDWebImageSwiftUI/Classes/Image.swift
+++ b/SDWebImageSwiftUI/Classes/Image.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwiftUI
 
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension Image {
     @inlinable init(platformImage: PlatformImage) {
         #if os(macOS)
@@ -20,13 +20,13 @@ extension Image {
     }
 }
 
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension PlatformImage {
     static var empty = PlatformImage()
 }
 
 #if !os(macOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension PlatformImage.Orientation {
     @inlinable var toSwiftUI: Image.Orientation {
         switch self {
@@ -52,7 +52,7 @@ extension PlatformImage.Orientation {
     }
 }
 
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension Image.Orientation {
     @inlinable var toPlatform: PlatformImage.Orientation {
         switch self {

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -12,7 +12,7 @@ import SDWebImage
 
 /// A Image observable object for handle image load process. This drive the Source of Truth for image loading status.
 /// You can use `@ObservedObject` to associate each instance of manager to your View type, which update your view's body from SwiftUI framework when image was loaded.
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public final class ImageManager : ObservableObject {
     /// loaded image, note when progressive loading, this will published multiple times with different partial image
     public var image: PlatformImage? {
@@ -136,7 +136,7 @@ public final class ImageManager : ObservableObject {
 }
 
 // Completion Handler
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension ImageManager {
     /// Provide the action when image load fails.
     /// - Parameters:

--- a/SDWebImageSwiftUI/Classes/ImagePlayer.swift
+++ b/SDWebImageSwiftUI/Classes/ImagePlayer.swift
@@ -11,7 +11,7 @@ import Combine
 import SDWebImage
 
 /// A Image observable object for handle aniamted image playback. This is used to avoid `@State` update may capture the View struct type and cause memory leak.
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public final class ImagePlayer : ObservableObject {
     var player: SDAnimatedImagePlayer?
     

--- a/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
+++ b/SDWebImageSwiftUI/Classes/ImageViewWrapper.swift
@@ -12,7 +12,7 @@ import SDWebImage
 #if !os(watchOS)
 
 /// Use wrapper to solve tne `UIImageView`/`NSImageView` frame size become image size issue (SwiftUI's Bug)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public class AnimatedImageViewWrapper : PlatformView {
     /// The wrapped actual image view, using SDWebImage's aniamted image view
     public var wrapped = SDAnimatedImageView()
@@ -67,7 +67,7 @@ public class AnimatedImageViewWrapper : PlatformView {
     }
 }
 
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension PlatformView {
     /// Adds constraints to this `UIView` instances `superview` object to make sure this always has the same size as the superview.
     /// Please note that this has no effect if its `superview` is `nil` – add this `UIView` instance as a subview before calling this.

--- a/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
+++ b/SDWebImageSwiftUI/Classes/Indicator/Indicator.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Combine
 
 /// A  type to build the indicator
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct Indicator<T> where T : View {
     var content: (Binding<Bool>, Binding<Double>) -> T
     
@@ -25,7 +25,7 @@ public struct Indicator<T> where T : View {
 }
 
 /// A observable model to report indicator loading status
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public class IndicatorStatus : ObservableObject {
     /// whether indicator is loading or not
     var isLoading: Bool = false {
@@ -48,7 +48,7 @@ public class IndicatorStatus : ObservableObject {
 /// A implementation detail View Modifier with indicator
 /// SwiftUI View Modifier construced by using a internal View type which modify the `body`
 /// It use type system to represent the view hierarchy, and Swift `some View` syntax to hide the type detail for users
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct IndicatorViewModifier<T> : ViewModifier where T : View {
     
     /// The loading status
@@ -72,7 +72,7 @@ public struct IndicatorViewModifier<T> : ViewModifier where T : View {
     }
 }
 
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension Indicator where T == AnyView {
     /// Activity Indicator
     public static var activity: Indicator<T> {
@@ -90,7 +90,7 @@ extension Indicator where T == AnyView {
     }
 }
 
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension Indicator where T == AnyView {
     /// Progress Indicator
     public static var progress: Indicator<T> {

--- a/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
+++ b/SDWebImageSwiftUI/Classes/SDWebImageSwiftUI.swift
@@ -11,53 +11,53 @@ import SwiftUI
 @_exported import SDWebImage // Automatically import SDWebImage
 
 #if os(macOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformImage = NSImage
 #else
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformImage = UIImage
 #endif
 
 #if os(macOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformView = NSView
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformView = UIView
 #endif
 #if os(watchOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformView = WKInterfaceObject
 #endif
 
 #if os(macOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformViewRepresentable = NSViewRepresentable
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformViewRepresentable = UIViewRepresentable
 #endif
 #if os(watchOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public typealias PlatformViewRepresentable = WKInterfaceObjectRepresentable
 #endif
 
 #if os(macOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension NSViewRepresentable {
     typealias PlatformViewType = NSViewType
 }
 #endif
 #if os(iOS) || os(tvOS) || os(visionOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension UIViewRepresentable {
     typealias PlatformViewType = UIViewType
 }
 #endif
 #if os(watchOS)
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension WKInterfaceObjectRepresentable {
     typealias PlatformViewType = WKInterfaceObjectType
 }

--- a/SDWebImageSwiftUI/Classes/Transition/Transition.swift
+++ b/SDWebImageSwiftUI/Classes/Transition/Transition.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension AnyTransition {
     
     /// Fade-in transition

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -47,7 +47,7 @@ public enum WebImagePhase {
 }
 
 /// Data Binding Object, only properties in this object can support changes from user with @State and refresh
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class WebImageModel : ObservableObject {
     /// URL image
     @Published var url: URL?
@@ -56,7 +56,7 @@ final class WebImageModel : ObservableObject {
 }
 
 /// Completion Handler Binding Object, supports dynamic @State changes
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class WebImageHandler: ObservableObject {
     // Completion Handler
     @Published var successBlock: ((PlatformImage, Data?, SDImageCacheType) -> Void)?
@@ -65,7 +65,7 @@ final class WebImageHandler: ObservableObject {
 }
 
 /// Configuration Binding Object, supports dynamic @State changes
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 final class WebImageConfiguration: ObservableObject {
     var retryOnAppear: Bool = true
     var cancelOnDisappear: Bool = true
@@ -79,7 +79,7 @@ final class WebImageConfiguration: ObservableObject {
 }
 
 /// A Image View type to load image from url. Supports static/animated image format.
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct WebImage<Content> : View where Content: View {
     var transaction: Transaction
     
@@ -344,7 +344,7 @@ public struct WebImage<Content> : View where Content: View {
 }
 
 // Layout
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension WebImage {
     func configure(_ block: @escaping (Image) -> Image) -> WebImage {
         var result = self
@@ -382,7 +382,7 @@ extension WebImage {
 }
 
 // Completion Handler
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension WebImage {
     
     /// Provide the action when image load fails.
@@ -414,7 +414,7 @@ extension WebImage {
 }
 
 // WebImage Modifier
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension WebImage {
     /// Control the behavior to retry the failed loading when view become appears again
     /// - Parameter flag: Whether or not to retry the failed loading
@@ -432,7 +432,7 @@ extension WebImage {
 }
 
 // Indicator
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension WebImage {
     
     /// Associate a indicator when loading image with url
@@ -449,7 +449,7 @@ extension WebImage {
 }
 
 // Animated Image
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 extension WebImage {
     
     /// Total loop count for animated image rendering. Defaults to nil.
@@ -517,7 +517,7 @@ extension WebImage {
 }
 
 #if DEBUG
-@available(iOS 14.0, OSX 11.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 struct WebImage_Previews : PreviewProvider {
     static var previews: some View {
         Group {


### PR DESCRIPTION
This PR replaces `OSX` with `macOS` in `available` attributes.
It seems that using `macOS` is now recommended:
https://docs.swift.org/swift-book/documentation/the-swift-programming-language/attributes/#available