### PR TITLE
Fix the transition visual jump between placeholderImage and final image for AnimatedImage

### DIFF
--- a/SDWebImageSwiftUI/Classes/AnimatedImage.swift
+++ b/SDWebImageSwiftUI/Classes/AnimatedImage.swift
@@ -276,7 +276,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
                 self.imageHandler.failureBlock?(error ?? NSError())
             }
             // Finished loading, async
-            finishUpdateView(view, context: context, image: image)
+            finishUpdateView(view, context: context)
         }
     }
     
@@ -364,7 +364,7 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
         
         // Finished loading, sync
-        finishUpdateView(view, context: context, image: view.wrapped.image)
+        finishUpdateView(view, context: context)
         
         if let viewUpdateBlock = imageHandler.viewUpdateBlock {
             viewUpdateBlock(view.wrapped, context)
@@ -383,13 +383,8 @@ public struct AnimatedImage : PlatformViewRepresentable {
         }
     }
     
-    func finishUpdateView(_ view: AnimatedImageViewWrapper, context: Context, image: PlatformImage?) {
+    func finishUpdateView(_ view: AnimatedImageViewWrapper, context: Context) {
         // Finished loading
-        if let imageSize = image?.size {
-            view.imageSize = imageSize
-        } else {
-            view.imageSize = nil
-        }
         configureView(view, context: context)
         layoutView(view, context: context)
     }

--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -60,6 +60,7 @@ public final class ImageManager : ObservableObject {
     weak var currentOperation: SDWebImageOperation? = nil
 
     var currentURL: URL?
+    var transaction = Transaction()
     var successBlock: ((PlatformImage, Data?, SDImageCacheType) -> Void)?
     var failureBlock: ((Error) -> Void)?
     var progressBlock: ((Int, Int) -> Void)?
@@ -106,18 +107,20 @@ public final class ImageManager : ObservableObject {
                 // So previous View struct call `onDisappear` and cancel the currentOperation
                 return
             }
-            self.image = image
-            self.error = error
-            self.isIncremental = !finished
-            if finished {
-                self.imageData = data
-                self.cacheType = cacheType
-                self.indicatorStatus.isLoading = false
-                self.indicatorStatus.progress = 1
-                if let image = image {
-                    self.successBlock?(image, data, cacheType)
-                } else {
-                    self.failureBlock?(error ?? NSError())
+            withTransaction(transaction) {
+                self.image = image
+                self.error = error
+                self.isIncremental = !finished
+                if finished {
+                    self.imageData = data
+                    self.cacheType = cacheType
+                    self.indicatorStatus.isLoading = false
+                    self.indicatorStatus.progress = 1
+                    if let image = image {
+                        self.successBlock?(image, data, cacheType)
+                    } else {
+                        self.failureBlock?(error ?? NSError())
+                    }
                 }
             }
         }

--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -81,8 +81,6 @@ final class WebImageConfiguration: ObservableObject {
 /// A Image View type to load image from url. Supports static/animated image format.
 @available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *)
 public struct WebImage<Content> : View where Content: View {
-    var transaction: Transaction
-    
     var configurations: [(Image) -> Image] = []
     
     var content: (WebImagePhase) -> Content
@@ -146,10 +144,10 @@ public struct WebImage<Content> : View where Content: View {
         imageModel.context = context
         _imageModel = ObservedObject(wrappedValue: imageModel)
         let imageManager = ImageManager()
+        imageManager.transaction = transaction
         _imageManager = StateObject(wrappedValue: imageManager)
         _indicatorStatus = ObservedObject(wrappedValue: imageManager.indicatorStatus)
         
-        self.transaction = transaction
         self.content = { phase in
             content(phase)
         }


### PR DESCRIPTION
This close the issue during the changes of https://github.com/SDWebImage/SDWebImageSwiftUI/pull/324

Also, the `WebImage` should use that `Transaction` during the image loading status changed