### PR TITLE
Fix for Hang Issue: Improving App Performance with Asynchronous Image…

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -71,7 +71,7 @@ public final class ImageManager : ObservableObject {
     /// - Parameter url: The image url
     /// - Parameter options: The options to use when downloading the image. See `SDWebImageOptions` for the possible values.
     /// - Parameter context: A context contains different options to perform specify changes or processes, see `SDWebImageContextOption`. This hold the extra objects which `options` enum can not hold.
-    public func load(url: URL?, options: SDWebImageOptions = [], context: [SDWebImageContextOption : Any]? = nil) {
+    public func load(url: URL?, options: SDWebImageOptions = [], context: [SDWebImageContextOption : Any]? = nil) async {
         let manager: SDWebImageManager
         if let customManager = context?[.customManager] as? SDWebImageManager {
             manager = customManager
@@ -127,7 +127,7 @@ public final class ImageManager : ObservableObject {
     }
     
     /// Cancel the current url loading
-    public func cancel() {
+    public func cancel() async {
         if let operation = currentOperation {
             operation.cancel()
             currentOperation = nil


### PR DESCRIPTION
My app hangs when multiple web image loads on the screen using a scroll view, because all the processes run on the main thread. Therefore, I made the load() and cancel() methods asynchronous, separating the tasks to other threads, so the app works smoothly.