### PR TITLE
Fixed old version compiler does not support automatic self capture in Xcode 14.2 and Swift 5.7.2

### DIFF
--- a/SDWebImageSwiftUI/Classes/ImageManager.swift
+++ b/SDWebImageSwiftUI/Classes/ImageManager.swift
@@ -107,7 +107,7 @@ public final class ImageManager : ObservableObject {
                 // So previous View struct call `onDisappear` and cancel the currentOperation
                 return
             }
-            withTransaction(transaction) {
+            withTransaction(self.transaction) {
                 self.image = image
                 self.error = error
                 self.isIncremental = !finished


### PR DESCRIPTION
Getting an issue : Reference to property 'transaction' in closure requires explicit use of 'self' to make capture semantics explicit in ImageManager.

It is fixed by replacing `withTransaction(transaction)` with ` withTransaction(self.transaction)` in ImageManager.swift at line 110