### PR TITLE
fix: remove duplicate placeholder rendering in phase-based content closure

### DIFF
--- a/SDWebImageSwiftUI/Classes/WebImage.swift
+++ b/SDWebImageSwiftUI/Classes/WebImage.swift
@@ -164,7 +164,6 @@ public struct WebImage<Content> : View where Content: View {
                     displayImage()
                 }
             } else {
-                content((imageManager.error != nil) ? .failure(imageManager.error!) : .empty)
                 setupInitialState()
                 // Load Logic
                 .onAppear {


### PR DESCRIPTION
## Problem

When using the phase-based content closure API, the placeholder content is rendered twice in the ZStack — once directly via `content()` and once via `setupInitialState()` → `setupPlaceholder()`.

This causes semi-transparent placeholder colors to appear darker than expected due to double-layering.

For example, a 5% black placeholder (`Color.black.opacity(0.05)`) renders at ~9.75% effective opacity instead of 5%.

## Solution

Remove the redundant `content()` call from the `else` branch. `setupInitialState()` already returns the placeholder via `setupPlaceholder()`, which calls the same `content()` with the same phase and additionally applies `.id(imageModel.url)` for correct SwiftUI view identity tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved placeholder display consistency by adjusting how placeholders are initialized and rendered during image loading and error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->